### PR TITLE
Prefill improvements: 119 -> 210 tok/s at 32k depth, sparse FA 8.16 -> 1.10 seconds

### DIFF
--- a/docs/development/DSV4-vulkan-sparse-prefill-progress.md
+++ b/docs/development/DSV4-vulkan-sparse-prefill-progress.md
@@ -257,3 +257,95 @@ GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
 ```
 
 Always run these sequentially. Do not run a compiler concurrently on this APU.
+
+## Experimental raw-prefix split prototype
+
+An uncommitted follow-up prototype was tested after commit `24c7ead76cc1a9631fa1b42b0bfa53a15169e1ba`. Check `git status` before continuing. It was initially tested with `GGML_VK_FA_TOPK_SPLIT=1`. After the successful 32k run, the split path was changed to default-on for a llama-server coherence test. Set `GGML_VK_FA_TOPK_SPLIT=0` to restore the single cooperative sparse kernel.
+
+Stage profiling on the exact production sparse shape (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) showed:
+
+```text
+cooperative QK and selected-K gather:   88.885 ms
+softmax increment:                       4.909 ms
+cooperative PV and output increment:   128.399 ms
+full cooperative sparse kernel:        222.193 ms
+```
+
+PV and output were 57.8% of the kernel. More importantly, most active keys are not sparse: all 2,304 raw-prefix rows are contiguous, while only 512 compressed rows use top-K indices. The prototype therefore makes two attention partitions:
+
+1. Ordinary optimized Vulkan cooperative FA processes the contiguous raw prefix.
+2. The cooperative top-K shader processes only the 512 selected compressed rows.
+3. The existing split-K reduction combines both online-softmax partitions and applies sinks.
+
+This preserves the exact raw-prefix, sparse top-K, causal mask, and softmax semantics. It reuses the existing ordinary FA and split-K reduction rather than adding a new subsystem.
+
+The exact-shape microbenchmark improved from 222.19 ms to 111.33 ms. Its steady split stages were about 62-64 ms raw-prefix FA, 43-46 ms selected sparse FA, and 3.6-3.9 ms reduction.
+
+Correctness validation:
+
+```bash
+GGML_VK_FA_TOPK_SPLIT=1 ./build/bin/test-backend-ops test \
+  -b Vulkan0 -o FLASH_ATTN_EXT -p 'n_top_k='
+
+./build/bin/test-backend-ops test -b Vulkan0 -o FLASH_ATTN_EXT
+```
+
+Results were 8/8 sparse top-K cases and 13,296/13,296 complete Vulkan FA cases against the CPU reference. No NaN or Inf failure occurred.
+
+Canonical 32k prototype command:
+
+```bash
+GGML_VK_FA_TOPK_SPLIT=1 GGML_VK_PERF_LOGGER=1 ./build/bin/llama-bench \
+  -m ~/Projects/docker/localLLaMA/models/models--unsloth--DeepSeek-V4-Flash-0731-GGUF/snapshots/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00001-of-00004.gguf \
+  -r 1 -d 32768 -p 2048 -ub 2048 -fa 1 -n 0 \
+  > /tmp/dsv4-vulkan-split-32k.log 2>&1
+```
+
+Final 32k result:
+
+```text
+32k context, PP 2048, ub 2048
+
+Old scalar:          112.29 tok/s, 18.1957 s total, 8.84496 s sparse FA
+Committed coopmat:   152.32 tok/s, 13.4032 s total, 4.44701 s sparse FA
+Experimental split: 208.70 tok/s,  9.7704 s total, 1.20170 s split sparse FA
+
+Experimental split stages:
+raw-prefix FA:       0.210775 s total, 10.037 ms/layer
+selected sparse FA:  0.908190 s total, 43.247 ms/layer
+split reduction:     0.082732 s total,  3.940 ms/layer
+Lightning Indexer:   1.110410 s total, 52.877 ms/layer
+TOP_K:               0.077394 s total,  3.685 ms/layer
+```
+
+Relative to the committed cooperative path, throughput improved 37.0%, total Vulkan time fell 27.1%, and sparse FA time fell 73.0%. Relative to the old scalar path, throughput improved 85.9%, total Vulkan time fell 46.3%, and sparse FA time fell 86.4%.
+
+The main unresolved tradeoff is scratch memory. At PP2048, the two output partitions use about 539 MiB because each stores an f32 partial output for 512 dimensions x 64 heads x 2048 queries, plus L/M data. The device maximum storage-buffer range is checked and the code falls back when the allocation is unavailable. The path is temporarily default-on for a llama-server coherence test but should not be finalized without discussing this footprint. A likely next step is to avoid materializing both full output partitions, for example by directly merging the selected partition into the raw result or processing query tiles, while retaining the measured split-path speed.
+
+The old sparse selection heuristic required `total_k >= 3 * active_k`. For the coherence test it now selects sparse attention whenever `total_k > active_k`; equality still uses dense FA because no keys are pruned. The shape, capability, and allocation gates remain unchanged.
+
+Prototype logs:
+
+- `/tmp/dsv4-fa-exact-qk.log`
+- `/tmp/dsv4-fa-exact-softmax.log`
+- `/tmp/dsv4-fa-exact-full.log`
+- `/tmp/dsv4-fa-exact-split.log`
+- `/tmp/dsv4-fa-split-correctness.log`
+- `/tmp/dsv4-fa-all-correctness.log`
+- `/tmp/dsv4-vulkan-split-32k.log`
+
+## Llama-server coherence check
+
+After making the split path default-on and changing the sparse crossover to `total_k > active_k`, `llama-server` produced a coherent response from a 2,044-token prompt at significant context depth. The final profiler block confirmed that all 21 sparse-attention layers used the split path:
+
+```text
+FA_TOP_K_RAW:       0.179223 s total,  8.534 ms/layer
+FA_TOP_K_SELECTED:  0.886629 s total, 42.220 ms/layer
+FA_TOP_K_REDUCE:    0.083240 s total,  3.964 ms/layer
+Split sparse FA:    1.149092 s total, 54.719 ms/layer
+Lightning Indexer:  1.054610 s total, 50.220 ms/layer
+TOP_K:               0.044540 s total,  2.121 ms/layer
+Total Vulkan:        9.797560 s
+```
+
+This closely matches the canonical PP2048 llama-bench result of 9.770 s total and 1.202 s split sparse FA. The focused sparse CPU-reference test was rerun after the crossover change and passed 8/8 cases.

--- a/docs/development/DSV4-vulkan-sparse-prefill-progress.md
+++ b/docs/development/DSV4-vulkan-sparse-prefill-progress.md
@@ -1,0 +1,259 @@
+# DeepSeek V4 Vulkan sparse prefill progress
+
+This file is a self-contained handoff for the DeepSeek V4 sparse-attention prompt-processing optimization on AMD Strix Halo. Read the repository `AGENTS.md` and `CONTRIBUTING.md` before continuing.
+
+## Repository state
+
+- Repository: `https://github.com/Nathanw1014/llama.cpp`
+- Branch: `strix-halo-vulkan`
+- Starting commit: `baf0025de861c6f6ea3720fa81c52ae1b2e6c078`
+- Target GPU: AMD Radeon 8060S / gfx1151, RADV, Vulkan, wave64
+- The device reports `GL_KHR_cooperative_matrix`, f16 inputs with f32 accumulation, 64 KiB shared memory, and a maximum 512-thread workgroup used by this path.
+
+The implementation is not upstream `ggml-org/llama.cpp`. It builds on this branch's DeepSeek V4 graph, Lightning Indexer, sparse top-K hint, decode gather path, fused HC kernels, and Vulkan profiler changes.
+
+## Important execution constraints
+
+The system is an APU. CPU compilation and GPU benchmarking share power and memory bandwidth. Never build and benchmark at the same time. Serialize all builds, correctness tests, and performance tests.
+
+GPU commands must run with host GPU access. In an agent sandbox, request elevated/out-of-sandbox execution. A sandboxed benchmark showed only CPU activity and is invalid.
+
+Redirect the full model benchmark to a log. Inspect only the last profiler block with `tail`; do not load the full log into agent context.
+
+## Build and ccache
+
+The build directory is `build`, configured as Release with Vulkan enabled. The default ccache directory was read-only in the agent environment, so use a writable directory:
+
+```bash
+cmake -S . -B build \
+  -DGGML_VULKAN=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+CCACHE_DIR=/tmp/llama-cpp-ccache cmake --build build --config Release \
+  --target llama-bench test-backend-ops -j "$(nproc)"
+
+CCACHE_DIR=/tmp/llama-cpp-ccache ccache -s
+```
+
+ccache was verified active. The final build reported direct hits. Note that an incremental change to `ggml-vulkan.cpp` is one large C++ translation unit and therefore uses one compiler core even with `-j`. Shader object regeneration can run in parallel.
+
+## Canonical benchmark command
+
+Do not change or omit switches for the 32k acceptance run:
+
+```bash
+GGML_VK_PERF_LOGGER=1 ./build/bin/llama-bench \
+  -m ~/Projects/docker/localLLaMA/models/models--unsloth--DeepSeek-V4-Flash-0731-GGUF/snapshots/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00001-of-00004.gguf \
+  -r 1 -d 32768 -p 2048 -ub 2048 -fa 1 -n 0 \
+  > /tmp/dsv4-vulkan-32k.log 2>&1
+
+tail -n 180 /tmp/dsv4-vulkan-32k.log
+```
+
+The known model path exists on the target system.
+
+## Graph and dispatch findings
+
+DeepSeek V4 builds the Lightning Indexer and sparse attention in `src/models/deepseek4.cpp`:
+
+1. `build_lid_top_k()` creates indexer Q/K/weights and calls `ggml_lightning_indexer()`.
+2. `ggml_top_k()` selects up to `hparams.indexer_top_k` compressed-cache indices for every query token.
+3. `build_csa_lid_attention()` concatenates the raw SWA K prefix with compressed CSA K, builds a dense mask carrying the same sparse selection, and calls `build_attn_mha(..., top_k, raw_k->ne[2])`.
+4. `build_attn_mha()` attaches `top_k` and `n_kv_raw` to `GGML_OP_FLASH_ATTN_EXT` through `ggml_flash_attn_ext_add_top_k()`.
+
+At the final 32k PP2048 batch:
+
+- total K rows: 11,008
+- `n_kv_raw`: 2,304 raw SWA rows, always attended subject to the mask
+- `n_top_k`: 512 selected compressed rows per query token
+- active rows: 2,816
+- selectable compressed region: 8,704
+
+The custom Vulkan path is selected by `ggml_vk_flash_attn_top_k()` before ordinary FA. Its gate requires the DeepSeek V4 shape and `total_k >= 3 * (n_kv_raw + n_top_k)`. The final shape satisfies `11008 >= 3 * 2816`.
+
+The old `flash_attn_top_k.comp` shader is scalar/subgroup code. One 512-thread workgroup covers eight heads for one query token. It stages 16 selected 512-wide K/V rows, computes QK with scalar FMAs and `subgroupAdd`, updates online softmax one key at a time, and accumulates PV manually. It does not use cooperative matrices.
+
+The top-K set differs by query token but is shared by all 64 query heads for that token. This makes the attention for one token a regular matrix problem across heads and selected keys despite sparse per-token indexing.
+
+## Root cause evidence
+
+The existing Vulkan timestamp infrastructure was extended with `ggml_vk_perf_mark_subop()` after the sparse dispatch. This reports the sparse kernel separately as `FA_TOP_K_SPARSE (sub-op)` or `FA_TOP_K_CM (sub-op)`.
+
+Focused test shape:
+
+```bash
+GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
+  -b Vulkan0 -o FLASH_ATTN_EXT \
+  -p 'kv=32768,nb=512,n_kv_raw=1024,n_top_k=512,sinks=0'
+```
+
+Results:
+
+- old scalar sparse kernel: 61.42 ms, 1.68 TFLOPS of useful active-set work
+- ordinary dense FA diagnostic (`GGML_VK_FA_TOPK=0`): 255.97 ms, about 8.7 TFLOPS over the full dense work
+- final cooperative sparse kernel: 32.55 ms, 3.17 TFLOPS of useful active-set work
+
+The residual `FLASH_ATTN_EXT` interval after the sparse timestamp is only about 4-7 us. The cost is inside the shader, not dispatch or surrounding synchronization.
+
+A temporary uniform stage-profiling mode was used and removed. For the final 32-head tile:
+
+- selected K gather + cooperative QK: 14.30 ms
+- gather + QK + serial softmax: 26.34 ms
+- gather + QK + parallel softmax: 15.53 ms
+- full kernel: 32.55 ms
+- the remaining cooperative PV/output portion is about 17.0 ms
+
+The old scalar shader was compute/issue inefficient. Dense FA proved matrix hardware is much faster but was still too expensive because it processes all K rows. The final implementation preserves sparsity and uses the matrix hardware for both QK and PV.
+
+## Implementation
+
+Files changed:
+
+- `ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp`
+  - New cooperative-matrix sparse prefill shader.
+  - One 512-thread workgroup covers 32 query heads for one token.
+  - Eight wave64 subgroups cover two 16-head tiles by four 16-key or 16-output-dimension tiles.
+  - Processes 64 selected keys per online-softmax block.
+  - Stages only indexed selected K/V tiles, never the full K range.
+  - Uses f16 cooperative-matrix inputs and f32 accumulation for QK and PV.
+  - Uses a 16-lane segmented softmax per head. XOR subgroup shuffles reduce max and sum for four independent heads per wave without workgroup barriers.
+  - Keeps f32 output accumulators and normalizes after all active blocks.
+  - Preserves the raw prefix, top-K index validation, mask, sinks, stream strides, and K == V latent behavior.
+- `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp`
+  - Embeds the new shader when cooperative-matrix shader support is available.
+- `ggml/src/ggml-vulkan/ggml-vulkan.cpp`
+  - Adds the cooperative sparse pipeline when the device supports the required 16x16x16 f16/f32 cooperative matrix shape.
+  - Selects it by capability and keeps the scalar shader as fallback.
+  - Adds `GGML_VK_FA_TOPK=0` to force ordinary dense FA for diagnostics.
+  - Adds `GGML_VK_FA_TOPK_CM=0` to force the old scalar sparse shader for A/B tests.
+  - Adds sparse sub-operation timestamps through the existing profiler.
+
+The path is capability-based, not hardcoded to Strix Halo. The current sparse shape gate remains DeepSeek V4-specific. Devices without the required cooperative matrix support keep the correct scalar sparse or dense fallback.
+
+Two discarded prototypes are useful context:
+
+- A 16-head, 64-key streaming cooperative tile was correct and reduced the focused test from 61.4 to 44.6 ms.
+- Keeping 32 complete 512-wide K/V rows in LDS grew shared memory to about 41 KiB, reduced residency, doubled block/barrier count, and regressed to 73.8 ms. Do not retry full-row LDS staging without solving occupancy.
+- A 32-head, 64-key streaming tile halved irregular row loads but initially stayed near 44.7 ms because serial softmax cost about 11.5 ms. Parallel segmented softmax produced the final 32.55 ms result.
+
+## Correctness validation
+
+Run:
+
+```bash
+./build/bin/test-backend-ops test -b Vulkan0 -o FLASH_ATTN_EXT -p 'n_top_k='
+```
+
+Final result: 8/8 sparse top-K FA cases passed against the CPU reference. Cases include:
+
+- decode and short batches that use dense/gather fallback
+- sparse prefill batch sizes 64 and 128
+- `n_kv_raw` plus top-K selection
+- invalid top-K index handling from the test fixture
+- sinks enabled and disabled
+- sparse threshold transitions
+- an active-key count of 193, which exercises a partial final 64-key block
+
+The test uses the existing FA tolerance of NMSE <= `5e-4`. No NaN or Inf failure occurred. The implementation changes Q and probability inputs to f16 cooperative-matrix operands with f32 accumulation, matching the precision strategy of ordinary Vulkan cooperative FA.
+
+Still desirable before broader submission:
+
+- compare model logits on controlled prompts between `GGML_VK_FA_TOPK_CM=0` and the default cooperative path
+
+## Canonical 32k results
+
+Exact clean runs, same command and machine, no concurrent build:
+
+```text
+32k context, PP 2048, ub 2048
+
+Before (commit baf0025de):
+112.29 tok/s
+Total Vulkan: 18.1957 s
+Sparse FA: 8.84496 s, 421.189 ms/layer
+Lightning Indexer: 1.19438 s
+TOP_K: 0.076948 s
+
+After:
+152.32 tok/s
+Total Vulkan: 13.4032 s
+Sparse FA: 4.44701 s, 211.762 ms/layer
+Lightning Indexer: 1.13156 s
+TOP_K: 0.073945 s
+
+Change:
+Throughput: +35.65%
+Total Vulkan time: -26.34%
+Sparse FA time: -49.72%
+Sparse FA saved: 4.398 s
+Total GPU time saved: 4.793 s
+```
+
+The profiler now lists the optimized dispatch as `FA_TOP_K_CM (sub-op)`. The following residual `FLASH_ATTN_EXT` line is only the post-mark interval and must not be interpreted as the kernel time.
+
+## Context-depth measurements
+
+All points use PP2048, ub2048, FA enabled, one repetition, and no token generation. They were run sequentially with no compiler active:
+
+```text
+Existing depth    tok/s    Total Vulkan    Final large FA    Lightning Indexer    TOP_K
+0                 253.44    8.041 s          0.294 s           0.095 s               0.001 s
+8192              211.01    9.666 s          1.625 s           0.379 s               0.022 s
+16384             177.19   11.518 s          3.031 s           0.678 s               0.044 s
+32768             152.32   13.403 s          4.447 s           1.132 s               0.074 s
+```
+
+At 0, 8k, and 16k, total K is below the existing sparse-path gate `total_k >= 3 * (n_kv_raw + n_top_k)`. These points use the unchanged ordinary dense FA implementation, so the cooperative sparse change does not affect or regress them. At 32k, total K is 11,008 and the cooperative sparse path engages. The 32k `Final large FA` value is the `FA_TOP_K_CM (sub-op)` total; the lower-depth values are the large ordinary `FLASH_ATTN_EXT` totals.
+
+Logs:
+
+- `/tmp/dsv4-vulkan-cm-0k.log`
+- `/tmp/dsv4-vulkan-cm-8k.log`
+- `/tmp/dsv4-vulkan-cm-16k.log`
+- `/tmp/dsv4-vulkan-cm-32k.log`
+- `/tmp/dsv4-vulkan-baseline-clean.log`
+- `/tmp/dsv4-fa-cm-correctness-final.log`
+
+## Next optimization target
+
+The cooperative sparse FA remains the largest context-dependent cost at about 4.45 s total. Stage profiling indicates approximately 14.3 ms of focused-test time in gather/QK, about 1.2 ms in parallel softmax, and about 17 ms in PV/output.
+
+The next useful work is PV and output accumulation, not TOP_K. Investigate:
+
+- reducing repeated selected V staging across the two 32-head workgroups per token without increasing LDS enough to lose occupancy
+- reducing the eight output-dimension passes or retaining more PV state in cooperative fragments/registers
+- checking register count and spills for the 32 f32 output accumulators per invocation using RADV shader statistics
+- alternate 32-head layouts that keep the same eight-wave occupancy but improve PV scheduling
+- query-tile overlap/union gathering only if measured top-K overlap is high enough; a whole-2048-query union is unlikely to help
+
+Do not optimize TOP_K first. At 32k it is only about 74 ms total. Lightning Indexer is about 1.13 s and is the next context-dependent target only after sparse FA improves further.
+
+## Useful diagnostics
+
+Force old scalar sparse path:
+
+```bash
+GGML_VK_FA_TOPK_CM=0 GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
+  -b Vulkan0 -o FLASH_ATTN_EXT \
+  -p 'kv=32768,nb=512,n_kv_raw=1024,n_top_k=512,sinks=0'
+```
+
+Force ordinary dense FA:
+
+```bash
+GGML_VK_FA_TOPK=0 GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
+  -b Vulkan0 -o FLASH_ATTN_EXT \
+  -p 'kv=32768,nb=512,n_kv_raw=1024,n_top_k=512,sinks=0'
+```
+
+Default cooperative sparse path:
+
+```bash
+GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
+  -b Vulkan0 -o FLASH_ATTN_EXT \
+  -p 'kv=32768,nb=512,n_kv_raw=1024,n_top_k=512,sinks=0'
+```
+
+Always run these sequentially. Do not run a compiler concurrently on this APU.

--- a/docs/development/DSV4-vulkan-sparse-prefill-progress.md
+++ b/docs/development/DSV4-vulkan-sparse-prefill-progress.md
@@ -320,7 +320,7 @@ TOP_K:               0.077394 s total,  3.685 ms/layer
 
 Relative to the committed cooperative path, throughput improved 37.0%, total Vulkan time fell 27.1%, and sparse FA time fell 73.0%. Relative to the old scalar path, throughput improved 85.9%, total Vulkan time fell 46.3%, and sparse FA time fell 86.4%.
 
-The main unresolved tradeoff is scratch memory. At PP2048, the two output partitions use about 539 MiB because each stores an f32 partial output for 512 dimensions x 64 heads x 2048 queries, plus L/M data. The device maximum storage-buffer range is checked and the code falls back when the allocation is unavailable. The path is temporarily default-on for a llama-server coherence test but should not be finalized without discussing this footprint. A likely next step is to avoid materializing both full output partitions, for example by directly merging the selected partition into the raw result or processing query tiles, while retaining the measured split-path speed.
+The initial split implementation used 538,968,064 bytes (514 MiB) of scratch at PP2048 because each of two partitions stored an f32 partial output for 512 dimensions x 64 heads x 2048 queries, plus L/M data. This was subsequently reduced by query tiling as described below.
 
 The old sparse selection heuristic required `total_k >= 3 * active_k`. For the coherence test it now selects sparse attention whenever `total_k > active_k`; equality still uses dense FA because no keys are pruned. The shape, capability, and allocation gates remain unchanged.
 
@@ -349,3 +349,59 @@ Total Vulkan:        9.797560 s
 ```
 
 This closely matches the canonical PP2048 llama-bench result of 9.770 s total and 1.202 s split sparse FA. The focused sparse CPU-reference test was rerun after the crossover change and passed 8/8 cases.
+
+## Tiled split scratch optimization
+
+Commit `4bbe53e4775f0707de8158e4977a16ab770829da` used two full PP2048 output partitions. The same two-partition algorithm now processes at most 256 query tokens per tile and reuses the split scratch between tiles. Q, mask, top-K, and destination descriptors are offset to the tile while K/V remain shared. A Vulkan pipeline barrier separates reuse of each scratch tile.
+
+Scratch at PP2048 changed from:
+
+```text
+Before: 538,968,064 bytes (514 MiB)
+After:   67,371,008 bytes (64.25 MiB)
+Change:  8x reduction
+```
+
+The exact production-shape microbenchmark (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) measured:
+
+```text
+Full-batch two partitions: 114.65 ms
+256-query tiled path:      113.70 ms
+```
+
+Two one-partition alternatives were tested and discarded. Merging the raw partial directly inside the cooperative selected shader measured 119.17 ms. Writing selected output separately and using a lightweight merge kernel measured 120.45 ms. Both cut scratch in half but regressed because writing selected output outside the contiguous split layout increased the selected stage from about 44 ms to about 51 ms. Query tiling preserves the faster memory layout.
+
+Canonical 32k result after tiling:
+
+```text
+32k context, PP 2048, ub 2048
+
+Full-batch split: 208.70 tok/s, 9.77039 s total, 1.20170 s sparse FA
+Tiled split:      209.62 tok/s, 9.72897 s total, 1.18721 s sparse FA
+
+Tiled split stages:
+raw-prefix FA:       0.192879 s total, 168 tile dispatches
+selected sparse FA:  0.910153 s total, 168 tile dispatches
+split reduction:     0.084179 s total, 168 tile dispatches
+Lightning Indexer:   1.100230 s total
+TOP_K:               0.075158 s total
+```
+
+The 168 dispatch count is eight tiles x 21 sparse-attention layers. Relative to the full-batch split path, throughput improved 0.44%, total Vulkan time fell 0.42%, and sparse FA time fell 1.21%. The main result is the 8x scratch reduction without a performance regression.
+
+Final correctness after removing the discarded merge prototypes:
+
+- focused sparse top-K suite: 9/9 passed against the CPU reference, including a 257-query tile-boundary case
+- complete Vulkan Flash Attention suite: 13,296/13,296 passed
+- no NaN or Inf failure
+
+Logs:
+
+- `/tmp/dsv4-fa-exact-fused.log`
+- `/tmp/dsv4-fa-exact-merge.log`
+- `/tmp/dsv4-fa-exact-two-part-current.log`
+- `/tmp/dsv4-fa-exact-tiled.log`
+- `/tmp/dsv4-fa-tiled-final-correctness.log`
+- `/tmp/dsv4-fa-tiled-boundary-correctness.log`
+- `/tmp/dsv4-fa-tiled-all-correctness.log`
+- `/tmp/dsv4-vulkan-tiled-32k.log`

--- a/docs/development/DSV4-vulkan-sparse-prefill-progress.md
+++ b/docs/development/DSV4-vulkan-sparse-prefill-progress.md
@@ -262,7 +262,7 @@ Always run these sequentially. Do not run a compiler concurrently on this APU.
 
 An uncommitted follow-up prototype was tested after commit `24c7ead76cc1a9631fa1b42b0bfa53a15169e1ba`. Check `git status` before continuing. It was initially tested with `GGML_VK_FA_TOPK_SPLIT=1`. After the successful 32k run, the split path was changed to default-on for a llama-server coherence test. Set `GGML_VK_FA_TOPK_SPLIT=0` to restore the single cooperative sparse kernel.
 
-Stage profiling on the exact production sparse shape (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) showed:
+Stage profiling on the previously used 19,200-row sparse shape (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) showed:
 
 ```text
 cooperative QK and selected-K gather:   88.885 ms
@@ -362,7 +362,7 @@ After:   67,371,008 bytes (64.25 MiB)
 Change:  8x reduction
 ```
 
-The exact production-shape microbenchmark (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) measured:
+The previously used 19,200-row microbenchmark (`kv=19200,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0`) measured:
 
 ```text
 Full-batch two partitions: 114.65 ms
@@ -408,7 +408,7 @@ Logs:
 
 ## Selected PV probability reuse
 
-The selected cooperative-matrix stage remained the largest split sparse-FA component. Profiling the exact tiled production shape showed:
+The selected cooperative-matrix stage remained the largest split sparse-FA component. Profiling the tiled 19,200-row shape showed:
 
 ```text
 selected K gather and cooperative QK:  about 20.0 ms
@@ -429,7 +429,7 @@ LDS                      36,864    28,672 bytes
 static instructions      11,524    11,358
 ```
 
-The exact production-shape microbenchmark changed from 113.70 ms for the committed tiled path to 110.11 ms. The selected stage fell from about 45.5 ms to about 43.7 ms. The raw-prefix and reduction implementations are unchanged.
+The 19,200-row microbenchmark changed from 113.70 ms for the committed tiled path to 110.11 ms. The selected stage fell from about 45.5 ms to about 43.7 ms. The raw-prefix and reduction implementations are unchanged.
 
 Two canonical 32k runs after this change measured:
 
@@ -490,3 +490,98 @@ Logs:
 - `/tmp/dsv4-vulkan-32k-pmat-repeat.log`
 
 The next sparse-FA optimization should continue to target the selected PV/output half. The retained probability fragments remove redundant cooperative loads without increasing reported VGPR allocation. More invasive changes such as doubling the PV dimension tile can reduce barriers but must be designed around the eight available wave64 subgroups, 64 KiB LDS limit, and already high 192-VGPR allocation. Do not build a crossover matrix until the next kernel layout is settled because an optimization can shift the crossover.
+
+## Selected mask caching and deep-context micro matrix
+
+The sparse FA `kv` dimension is compressed K/V rows, not source-token context depth. For the tested DeepSeek V4 graph, a PP2048 batch uses 2,304 raw rows and approximately one compressed row per four source tokens. The useful synthetic mapping is:
+
+```text
+Source context    Sparse FA kv rows
+32k               11,008
+64k               19,200
+128k              35,584
+256k              68,352
+512k             133,888
+```
+
+The performance test registry now contains PP2048 cases at all five K extents with `n_kv_raw=2304` and `n_top_k=512`. Use this command template and replace `KV` with a value from the table:
+
+```bash
+GGML_VK_PERF_LOGGER=1 ./build/bin/test-backend-ops perf \
+  -b Vulkan0 -o FLASH_ATTN_EXT \
+  -p 'kv=KV,nb=2048,n_kv_raw=2304,n_top_k=512,sinks=0'
+```
+
+These are synthetic sparse-FA depth tests. They do not include the Lightning Indexer or the rest of the model graph and do not replace the canonical 32k llama-bench.
+
+The selected shader previously loaded the same selected-key mask value independently for all 32 heads during both softmax passes. The shader now loads each mask value once per 64-key block and reuses it from LDS. Q and probability storage also share one LDS allocation, while K and V staging share another because both pairs have disjoint lifetimes.
+
+Shader resources changed from the probability-reuse commit:
+
+```text
+                         Before    After
+VGPRs                    192       192
+VGPR spills              0         0
+LDS                      28,672    24,576 bytes
+static instructions      11,358    11,233
+```
+
+A 128-dimension V staging experiment was correct but rejected. With operand aliasing it used exactly 32 KiB LDS. It was 2.3% slower at simulated 32k, approximately equal at 64k, and 1.6% faster at 128k. The retained 64-dimension layout is better for the canonical 32k target and is simpler.
+
+Selected-mask caching improved every synthetic depth relative to the same 64-dimension operand-alias layout:
+
+```text
+Depth    Selected before    Selected after    Split total before    Split total after
+32k      43.16 ms           41.23 ms          109.45 ms             108.07 ms
+64k      43.22 ms           41.42 ms          110.45 ms             109.11 ms
+128k     52.26 ms           48.74 ms          119.15 ms             116.92 ms
+256k     51.64 ms           49.02 ms          118.06 ms             116.93 ms
+512k     51.33 ms           49.20 ms          117.87 ms             116.27 ms
+```
+
+The 256k case exposed a separate path-selection cutoff. The raw-prefix ordinary FA dispatch encoded its mask row stride in 16 bits and disabled split sparse FA above 65,535 K rows. It now uses a flagged convention that carries the full 32-bit mask stride in the existing `split_kv` push constant for this one-partition partial-output dispatch. No push-constant structure was enlarged. At simulated 256k, this changes the selected path from unsplit cooperative sparse FA at 206.22 ms to split sparse FA at 118.06 ms before mask caching, a 42.8% reduction. The 512k case also uses the split path successfully.
+
+Canonical 32k PP2048 after operand aliasing and selected-mask caching:
+
+```text
+Previous commit, two runs:
+209.57-211.03 tok/s
+Total Vulkan:             9.664-9.730 s
+Split sparse FA:          1.128-1.136 s
+  raw-prefix FA:          0.192-0.193 s
+  selected sparse FA:     0.850-0.860 s
+  split reduction:        0.083-0.086 s
+
+Current result:
+210.47 tok/s
+Total Vulkan:             9.68921 s
+Split sparse FA:          1.10160 s
+  raw-prefix FA:          0.192860 s
+  selected sparse FA:     0.821381 s
+  split reduction:        0.087354 s
+Lightning Indexer:        1.102230 s
+TOP_K:                    0.072488 s
+```
+
+The selected stage improves 3.4-4.5% and complete split sparse FA improves 2.3-3.0% relative to the previous commit's two canonical runs. End-to-end throughput remains within model-wide benchmark noise.
+
+Correctness:
+
+- focused sparse top-K suite: 9/9 passed
+- complete Vulkan Flash Attention suite: 13,297/13,297 passed
+- no NaN or Inf failure
+- simulated 256k and 512k performance cases both selected the split path and completed successfully
+
+Benchmark policy for this laptop APU: do not repeat llama-bench when the exact-shape microbenchmarks and the first canonical profiler block agree. Sustained load can lower GPU clocks and bias a repeat. Repeat only when the first result is anomalous or contradicts the microbenchmarks. Never build and benchmark concurrently.
+
+Logs:
+
+- `/tmp/dsv4-fa-mask-cache-32k.log`
+- `/tmp/dsv4-fa-mask-cache-64k.log`
+- `/tmp/dsv4-fa-mask-cache-128k.log`
+- `/tmp/dsv4-fa-mask-cache-256k.log`
+- `/tmp/dsv4-fa-mask-cache-512k.log`
+- `/tmp/dsv4-fa-final-micro-32k.log`
+- `/tmp/dsv4-fa-final-focused-correctness.log`
+- `/tmp/dsv4-fa-mask-cache-all-correctness.log`
+- `/tmp/dsv4-vulkan-32k-mask-cache.log`

--- a/docs/development/DSV4-vulkan-sparse-prefill-progress.md
+++ b/docs/development/DSV4-vulkan-sparse-prefill-progress.md
@@ -405,3 +405,88 @@ Logs:
 - `/tmp/dsv4-fa-tiled-boundary-correctness.log`
 - `/tmp/dsv4-fa-tiled-all-correctness.log`
 - `/tmp/dsv4-vulkan-tiled-32k.log`
+
+## Selected PV probability reuse
+
+The selected cooperative-matrix stage remained the largest split sparse-FA component. Profiling the exact tiled production shape showed:
+
+```text
+selected K gather and cooperative QK:  about 20.0 ms
+QK plus softmax:                       about 22.3 ms
+full selected stage:                   about 45.5 ms
+cooperative PV and output increment:   about 23.2 ms
+```
+
+PV and output were about 51% of the selected stage. The shader previously loaded each of four 16x16 probability cooperative-matrix fragments again for every one of the eight 64-dimension PV passes. The optimized shader loads these four fragments once per 64-key block and retains them across all PV dimension passes. This follows the probability-fragment lifetime used by ordinary cooperative Vulkan FA.
+
+The shader also aliases the shared score and PV-output matrices because their lifetimes do not overlap. Shader resource statistics changed as follows:
+
+```text
+                         Before    After
+VGPRs                    192       192
+VGPR spills              0         0
+LDS                      36,864    28,672 bytes
+static instructions      11,524    11,358
+```
+
+The exact production-shape microbenchmark changed from 113.70 ms for the committed tiled path to 110.11 ms. The selected stage fell from about 45.5 ms to about 43.7 ms. The raw-prefix and reduction implementations are unchanged.
+
+Two canonical 32k runs after this change measured:
+
+```text
+32k context, PP 2048, ub 2048
+
+Committed tiled reference:
+209.62 tok/s
+Total Vulkan:             9.72897 s
+Split sparse FA:          1.18721 s
+  raw-prefix FA:          0.192879 s
+  selected sparse FA:     0.910153 s
+  split reduction:        0.084179 s
+Lightning Indexer:        1.100230 s
+TOP_K:                    0.075158 s
+
+Probability reuse, run 1:
+211.03 tok/s
+Total Vulkan:             9.66363 s
+Split sparse FA:          1.12776 s
+  raw-prefix FA:          0.192078 s
+  selected sparse FA:     0.849862 s
+  split reduction:        0.085821 s
+Lightning Indexer:        1.098980 s
+TOP_K:                    0.071036 s
+
+Probability reuse, run 2:
+209.57 tok/s
+Total Vulkan:             9.72968 s
+Split sparse FA:          1.13553 s
+  raw-prefix FA:          0.192987 s
+  selected sparse FA:     0.859890 s
+  split reduction:        0.082653 s
+Lightning Indexer:        1.102550 s
+TOP_K:                    0.071474 s
+```
+
+The two-run selected-stage improvement is 5.5-6.6%, and the complete split sparse-FA improvement is 4.4-5.0%. The two-run throughput mean is 210.30 tok/s, 0.32% above the 209.62 tok/s reference. End-to-end noise in unrelated model kernels is larger than this small total-throughput change, but both profiler runs isolate a consistent gain in the modified selected stage.
+
+Correctness after the change:
+
+- focused sparse top-K suite: 9/9 passed against the CPU reference
+- complete Vulkan Flash Attention suite: 13,297/13,297 passed
+- pipeline statistics probe: 1/1 passed, with no SGPR or VGPR spills
+- no NaN or Inf failure
+
+Logs:
+
+- `/tmp/dsv4-fa-selected-qk-tiled.log`
+- `/tmp/dsv4-fa-selected-softmax-tiled.log`
+- `/tmp/dsv4-fa-lds-alias-stats.log`
+- `/tmp/dsv4-fa-pmat-stats.log`
+- `/tmp/dsv4-fa-exact-lds-alias.log`
+- `/tmp/dsv4-fa-exact-pmat.log`
+- `/tmp/dsv4-fa-pmat-correctness.log`
+- `/tmp/dsv4-fa-pmat-all-correctness.log`
+- `/tmp/dsv4-vulkan-32k-pmat.log`
+- `/tmp/dsv4-vulkan-32k-pmat-repeat.log`
+
+The next sparse-FA optimization should continue to target the selected PV/output half. The retained probability fragments remove redundant cooperative loads without increasing reported VGPR allocation. More invasive changes such as doubling the PV dimension tile can reduce barriers but must be designed around the eight available wave64 subgroups, 64 KiB LDS limit, and already high 192-VGPR allocation. Do not build a crossover matrix until the next kernel layout is settled because an optimization can shift the crossover.

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1040,6 +1040,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_lightning_indexer_cm_f16;
     vk_pipeline pipeline_lightning_indexer_decode_cm_f16;
     vk_pipeline pipeline_flash_attn_top_k_f16;
+    vk_pipeline pipeline_flash_attn_top_k_cm_f16;
     vk_pipeline pipeline_flash_attn_gather_f16;
     vk_pipeline pipeline_dsv4_hc_pre_f32;
     vk_pipeline pipeline_dsv4_hc_comb_f32;
@@ -6133,6 +6134,10 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
                 "lightning_indexer_decode_cm_f16", lightning_indexer_decode_cm_f16_len, lightning_indexer_decode_cm_f16_data, "main", 5,
                 sizeof(vk_op_lightning_indexer_push_constants), {16, 1, 1}, {device->subgroup_size}, 1, true, true,
                 device->subgroup_size);
+            ggml_vk_create_pipeline(device, device->pipeline_flash_attn_top_k_cm_f16,
+                "flash_attn_top_k_cm_f16", flash_attn_top_k_cm_f16_len, flash_attn_top_k_cm_f16_data, "main", 6,
+                sizeof(vk_op_flash_attn_top_k_push_constants), {1, 1, 1}, {512, device->subgroup_size}, 1, true, true,
+                device->subgroup_size);
         }
 #endif
         ggml_vk_create_pipeline(device, device->pipeline_flash_attn_top_k_f16,
@@ -11193,7 +11198,9 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
         const ggml_tensor * q, const ggml_tensor * k, const ggml_tensor * v,
         const ggml_tensor * mask, const ggml_tensor * sinks, ggml_tensor * dst) {
     const ggml_tensor * top_k = dst->src[5];
-    if (!top_k || !ctx->device->pipeline_flash_attn_top_k_f16 ||
+    static const char * top_k_env = getenv("GGML_VK_FA_TOPK");
+    if ((top_k_env && top_k_env[0] == '0') ||
+        !top_k || (!ctx->device->pipeline_flash_attn_top_k_f16 && !ctx->device->pipeline_flash_attn_top_k_cm_f16) ||
         q->type != GGML_TYPE_F32 || k->type != GGML_TYPE_F16 || v->type != GGML_TYPE_F16 ||
         !mask || mask->type != GGML_TYPE_F16 || top_k->type != GGML_TYPE_I32 ||
         q->ne[0] != 512 || q->ne[1] < 64 || k->ne[0] != 512 || v->ne[0] != 512 ||
@@ -11243,12 +11250,15 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
 
     const vk_subbuffer q_buf = ggml_vk_tensor_subbuffer(ctx, q);
     const vk_subbuffer sinks_buf = sinks ? ggml_vk_tensor_subbuffer(ctx, sinks) : q_buf;
-    vk_pipeline pipeline = ctx->device->pipeline_flash_attn_top_k_f16;
+    static const char * top_k_cm_env = getenv("GGML_VK_FA_TOPK_CM");
+    const bool use_cm = (!top_k_cm_env || top_k_cm_env[0] != '0') && ctx->device->pipeline_flash_attn_top_k_cm_f16;
+    vk_pipeline pipeline = use_cm ? ctx->device->pipeline_flash_attn_top_k_cm_f16 : ctx->device->pipeline_flash_attn_top_k_f16;
     ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
     ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
         {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, mask), sinks_buf,
          ggml_vk_tensor_subbuffer(ctx, top_k), ggml_vk_tensor_subbuffer(ctx, dst)},
-        pc, {(uint32_t) q->ne[1], (uint32_t) CEIL_DIV(q->ne[2], 8), (uint32_t) q->ne[3]});
+        pc, {(uint32_t) q->ne[1], (uint32_t) CEIL_DIV(q->ne[2], use_cm ? 32 : 8), (uint32_t) q->ne[3]});
+    ggml_vk_perf_mark_subop(ctx, subctx, use_cm ? "FA_TOP_K_CM (sub-op)" : "FA_TOP_K_SPARSE (sub-op)");
     return true;
 }
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -11260,7 +11260,7 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
 
     static const char * top_k_split_env = getenv("GGML_VK_FA_TOPK_SPLIT");
     const uint32_t mask_stride = (uint32_t) (mask->nb[1] / sizeof(ggml_fp16_t));
-    const bool try_split = use_cm && (!top_k_split_env || top_k_split_env[0] != '0') && n_kv_raw > 0 && top_k->ne[0] > 0 && mask_stride <= 0xffff;
+    const bool try_split = use_cm && (!top_k_split_env || top_k_split_env[0] != '0') && n_kv_raw > 0 && top_k->ne[0] > 0;
     if (try_split) {
         const uint32_t N = (uint32_t) q->ne[1];
         const uint32_t D = 512;
@@ -11306,7 +11306,8 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
                 }
 
                 const uint32_t n_head_log2 = 64;
-                const uint32_t packed_gqa = (mask_stride << 16) | 1;
+                const uint32_t mask_stride_in_split_kv = 1u << 31;
+                const uint32_t packed_gqa = mask_stride_in_split_kv | 1u;
                 const uint32_t packed_partitions = (partitions << 16) | 1;
                 const vk_subbuffer split_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_split_k, 0);
                 const vk_subbuffer k_buf = ggml_vk_tensor_subbuffer(ctx, k);
@@ -11339,7 +11340,7 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
                         k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
                         scale, 0.0f, 0.0f,
                         n_head_log2, 1.0f, 1.0f,
-                        packed_gqa, raw_kv, packed_partitions,
+                        packed_gqa, mask_stride, packed_partitions,
                     };
 
                     ggml_vk_dispatch_pipeline(ctx, subctx, raw_pipeline,

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1850,6 +1850,8 @@ struct vk_op_flash_attn_top_k_push_constants {
     uint32_t nb1, nb2, nb3;
     float scale;
     uint32_t has_sinks;
+    uint32_t profile_stage;
+    uint32_t split_mode;
 };
 static_assert(sizeof(vk_op_flash_attn_top_k_push_constants) <= 128);
 
@@ -11226,11 +11228,11 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
         return false;
     }
     const int64_t n_kv_active = n_kv_raw + top_k->ne[0];
-    if (k->ne[1] < 3 * n_kv_active) {
+    if (k->ne[1] <= n_kv_active) {
         return false;
     }
 
-    const vk_op_flash_attn_top_k_push_constants pc = {
+    vk_op_flash_attn_top_k_push_constants pc = {
         (uint32_t) q->ne[1], (uint32_t) k->ne[1], (uint32_t) n_kv_raw,
         (uint32_t) top_k->ne[0], (uint32_t) q->ne[2],
         (uint32_t) (q->nb[1] / sizeof(float)),
@@ -11245,14 +11247,105 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
         (uint32_t) (dst->nb[1] / sizeof(float)),
         (uint32_t) (dst->nb[2] / sizeof(float)),
         (uint32_t) (dst->nb[3] / sizeof(float)),
-        scale, sinks != nullptr,
+        scale, sinks != nullptr, 0, 0,
     };
 
     const vk_subbuffer q_buf = ggml_vk_tensor_subbuffer(ctx, q);
     const vk_subbuffer sinks_buf = sinks ? ggml_vk_tensor_subbuffer(ctx, sinks) : q_buf;
     static const char * top_k_cm_env = getenv("GGML_VK_FA_TOPK_CM");
     const bool use_cm = (!top_k_cm_env || top_k_cm_env[0] != '0') && ctx->device->pipeline_flash_attn_top_k_cm_f16;
+    static const char * top_k_profile_env = getenv("GGML_VK_FA_TOPK_PROFILE");
+    pc.profile_stage = use_cm && top_k_profile_env ? atoi(top_k_profile_env) : 0;
     vk_pipeline pipeline = use_cm ? ctx->device->pipeline_flash_attn_top_k_cm_f16 : ctx->device->pipeline_flash_attn_top_k_f16;
+
+    static const char * top_k_split_env = getenv("GGML_VK_FA_TOPK_SPLIT");
+    const uint32_t mask_stride = (uint32_t) (mask->nb[1] / sizeof(ggml_fp16_t));
+    const bool try_split = use_cm && (!top_k_split_env || top_k_split_env[0] != '0') && n_kv_raw > 0 && top_k->ne[0] > 0 && mask_stride <= 0xffff;
+    if (try_split) {
+        const uint32_t N = (uint32_t) q->ne[1];
+        const uint32_t D = 512;
+        const uint32_t NH = 64;
+        const uint32_t NS = (uint32_t) q->ne[3];
+        const uint32_t raw_kv = (uint32_t) n_kv_raw;
+        const uint32_t partitions = 2;
+        const bool f32acc = true;
+        vk_fa_tuning_params tuning = get_fa_tuning_params(ctx->device, D, D, N, raw_kv, GGML_TYPE_F16, GGML_TYPE_F16, f32acc);
+
+        const uint32_t q_stride = (uint32_t) (q->nb[1] / sizeof(float));
+        const uint32_t k_stride = (uint32_t) (k->nb[1] / sizeof(ggml_fp16_t));
+        const bool aligned = raw_kv % tuning.block_cols == 0 && (q_stride & 7) == 0 && (k_stride & 7) == 0;
+        const vk_fa_pipeline_state raw_state = get_fa_pipeline_state(ctx->device, tuning, D, D, aligned, f32acc,
+                                                                     true, false, false, GGML_TYPE_F16, GGML_TYPE_F16);
+        if (raw_state.path == FA_COOPMAT1 && ctx->device->pipeline_flash_attn_split_k_reduce) {
+            vk_pipeline raw_pipeline;
+            {
+                std::lock_guard<std::mutex> guard(ctx->device->compile_mutex);
+                auto & pipelines = ctx->device->pipeline_flash_attn_f32_f16;
+                auto it = pipelines.find(raw_state);
+                if (it != pipelines.end()) {
+                    raw_pipeline = it->second;
+                } else {
+                    pipelines[raw_state] = raw_pipeline = std::make_shared<vk_pipeline_struct>();
+                }
+            }
+            ggml_pipeline_request_descriptor_sets(ctx, raw_pipeline, 1);
+            ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+            ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_flash_attn_split_k_reduce, 1);
+
+            const uint64_t split_size = ((uint64_t) D * NH * sizeof(float) + NH * 2 * sizeof(float)) * partitions * N * NS;
+            if (split_size <= ctx->device->properties.limits.maxStorageBufferRange) {
+                if (ctx->prealloc_size_split_k < split_size) {
+                    ctx->prealloc_size_split_k = split_size;
+                    ggml_vk_preallocate_buffers(ctx, subctx);
+                }
+                if (ctx->prealloc_split_k_need_sync) {
+                    ggml_vk_sync_buffers(ctx, subctx);
+                }
+
+                const vk_subbuffer split_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_split_k, 0);
+                const uint32_t n_head_log2 = 64;
+                const uint32_t packed_gqa = (mask_stride << 16) | 1;
+                const uint32_t packed_partitions = (partitions << 16) | 1;
+                const vk_flash_attn_push_constants raw_pc = {
+                    N, raw_kv,
+                    NH, N, NS,
+                    NH, NS,
+                    1, NS,
+                    1, NS,
+                    (uint32_t) mask->ne[1], (uint32_t) mask->ne[2], (uint32_t) mask->ne[3],
+                    q_stride, (uint32_t) q->nb[2], (uint32_t) q->nb[3],
+                    k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
+                    k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
+                    scale, 0.0f, 0.0f,
+                    n_head_log2, 1.0f, 1.0f,
+                    packed_gqa, raw_kv, packed_partitions,
+                };
+
+                ggml_vk_dispatch_pipeline(ctx, subctx, raw_pipeline,
+                    {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, k),
+                     ggml_vk_tensor_subbuffer(ctx, mask), q_buf, split_buf, q_buf},
+                    raw_pc, {N, NH, NS});
+                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_RAW (sub-op)");
+
+                pc.split_mode = 1;
+                ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+                    {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, mask), sinks_buf,
+                     ggml_vk_tensor_subbuffer(ctx, top_k), split_buf},
+                    pc, {N, (uint32_t) CEIL_DIV(q->ne[2], 32), NS});
+                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_SELECTED (sub-op)");
+
+                ggml_vk_sync_buffers(ctx, subctx);
+                const vk_op_flash_attn_split_k_reduce_push_constants reduce_pc = {D, NH, N, NS, partitions, sinks != nullptr};
+                ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_flash_attn_split_k_reduce,
+                    {split_buf, sinks_buf, ggml_vk_tensor_subbuffer(ctx, dst)},
+                    reduce_pc, {NH, D, N * NS});
+                ctx->prealloc_split_k_need_sync = true;
+                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_REDUCE (sub-op)");
+                return true;
+            }
+        }
+    }
+
     ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
     ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
         {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, mask), sinks_buf,

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -11268,6 +11268,8 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
         const uint32_t NS = (uint32_t) q->ne[3];
         const uint32_t raw_kv = (uint32_t) n_kv_raw;
         const uint32_t partitions = 2;
+        const uint32_t tile_size = std::min(N, 256u);
+        const uint32_t n_tiles = CEIL_DIV(N, tile_size);
         const bool f32acc = true;
         vk_fa_tuning_params tuning = get_fa_tuning_params(ctx->device, D, D, N, raw_kv, GGML_TYPE_F16, GGML_TYPE_F16, f32acc);
 
@@ -11288,11 +11290,12 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
                     pipelines[raw_state] = raw_pipeline = std::make_shared<vk_pipeline_struct>();
                 }
             }
-            ggml_pipeline_request_descriptor_sets(ctx, raw_pipeline, 1);
-            ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
-            ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_flash_attn_split_k_reduce, 1);
+            ggml_pipeline_request_descriptor_sets(ctx, raw_pipeline, n_tiles);
+            ggml_pipeline_request_descriptor_sets(ctx, pipeline, n_tiles);
+            ggml_pipeline_request_descriptor_sets(ctx, ctx->device->pipeline_flash_attn_split_k_reduce, n_tiles);
 
-            const uint64_t split_size = ((uint64_t) D * NH * sizeof(float) + NH * 2 * sizeof(float)) * partitions * N * NS;
+            const uint64_t partition_size = ((uint64_t) D * NH + NH * 2) * sizeof(float) * tile_size * NS;
+            const uint64_t split_size = partition_size * partitions;
             if (split_size <= ctx->device->properties.limits.maxStorageBufferRange) {
                 if (ctx->prealloc_size_split_k < split_size) {
                     ctx->prealloc_size_split_k = split_size;
@@ -11302,45 +11305,63 @@ static bool ggml_vk_flash_attn_top_k(ggml_backend_vk_context * ctx, vk_context &
                     ggml_vk_sync_buffers(ctx, subctx);
                 }
 
-                const vk_subbuffer split_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_split_k, 0);
                 const uint32_t n_head_log2 = 64;
                 const uint32_t packed_gqa = (mask_stride << 16) | 1;
                 const uint32_t packed_partitions = (partitions << 16) | 1;
-                const vk_flash_attn_push_constants raw_pc = {
-                    N, raw_kv,
-                    NH, N, NS,
-                    NH, NS,
-                    1, NS,
-                    1, NS,
-                    (uint32_t) mask->ne[1], (uint32_t) mask->ne[2], (uint32_t) mask->ne[3],
-                    q_stride, (uint32_t) q->nb[2], (uint32_t) q->nb[3],
-                    k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
-                    k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
-                    scale, 0.0f, 0.0f,
-                    n_head_log2, 1.0f, 1.0f,
-                    packed_gqa, raw_kv, packed_partitions,
+                const vk_subbuffer split_buf = ggml_vk_subbuffer(ctx, ctx->prealloc_split_k, 0);
+                const vk_subbuffer k_buf = ggml_vk_tensor_subbuffer(ctx, k);
+                const vk_subbuffer mask_buf = ggml_vk_tensor_subbuffer(ctx, mask);
+                const vk_subbuffer top_buf = ggml_vk_tensor_subbuffer(ctx, top_k);
+                const vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst);
+                const auto sliced = [](const vk_subbuffer & buf, uint64_t offset) {
+                    return vk_subbuffer{buf.buffer, buf.offset + offset, buf.size - offset};
                 };
 
-                ggml_vk_dispatch_pipeline(ctx, subctx, raw_pipeline,
-                    {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, k),
-                     ggml_vk_tensor_subbuffer(ctx, mask), q_buf, split_buf, q_buf},
-                    raw_pc, {N, NH, NS});
-                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_RAW (sub-op)");
+                for (uint32_t tile = 0; tile < n_tiles; ++tile) {
+                    if (tile != 0) {
+                        ggml_vk_sync_buffers(ctx, subctx);
+                    }
+                    const uint32_t token_offset = tile * tile_size;
+                    const uint32_t tile_n = std::min(tile_size, N - token_offset);
+                    const vk_subbuffer tile_q = sliced(q_buf, (uint64_t) token_offset * q->nb[1]);
+                    const vk_subbuffer tile_mask = sliced(mask_buf, (uint64_t) token_offset * mask->nb[1]);
+                    const vk_subbuffer tile_top = sliced(top_buf, (uint64_t) token_offset * top_k->nb[1]);
+                    const vk_subbuffer tile_dst = sliced(dst_buf, (uint64_t) token_offset * dst->nb[2]);
+                    const vk_flash_attn_push_constants raw_pc = {
+                        tile_n, raw_kv,
+                        NH, tile_n, NS,
+                        NH, NS,
+                        1, NS,
+                        1, NS,
+                        (uint32_t) mask->ne[1], (uint32_t) mask->ne[2], (uint32_t) mask->ne[3],
+                        q_stride, (uint32_t) q->nb[2], (uint32_t) q->nb[3],
+                        k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
+                        k_stride, (uint32_t) k->nb[2], (uint32_t) k->nb[3],
+                        scale, 0.0f, 0.0f,
+                        n_head_log2, 1.0f, 1.0f,
+                        packed_gqa, raw_kv, packed_partitions,
+                    };
 
-                pc.split_mode = 1;
-                ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
-                    {q_buf, ggml_vk_tensor_subbuffer(ctx, k), ggml_vk_tensor_subbuffer(ctx, mask), sinks_buf,
-                     ggml_vk_tensor_subbuffer(ctx, top_k), split_buf},
-                    pc, {N, (uint32_t) CEIL_DIV(q->ne[2], 32), NS});
-                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_SELECTED (sub-op)");
+                    ggml_vk_dispatch_pipeline(ctx, subctx, raw_pipeline,
+                        {tile_q, k_buf, k_buf, tile_mask, tile_q, split_buf, tile_q},
+                        raw_pc, {tile_n, NH, NS});
+                    ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_RAW (sub-op)");
 
-                ggml_vk_sync_buffers(ctx, subctx);
-                const vk_op_flash_attn_split_k_reduce_push_constants reduce_pc = {D, NH, N, NS, partitions, sinks != nullptr};
-                ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_flash_attn_split_k_reduce,
-                    {split_buf, sinks_buf, ggml_vk_tensor_subbuffer(ctx, dst)},
-                    reduce_pc, {NH, D, N * NS});
-                ctx->prealloc_split_k_need_sync = true;
-                ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_REDUCE (sub-op)");
+                    pc.n_batch = tile_n;
+                    pc.split_mode = 1;
+                    ggml_vk_dispatch_pipeline(ctx, subctx, pipeline,
+                        {tile_q, k_buf, tile_mask, sinks_buf, tile_top, split_buf},
+                        pc, {tile_n, (uint32_t) CEIL_DIV(q->ne[2], 32), NS});
+                    ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_SELECTED (sub-op)");
+
+                    ctx->prealloc_split_k_need_sync = true;
+                    ggml_vk_sync_buffers(ctx, subctx);
+                    const vk_op_flash_attn_split_k_reduce_push_constants reduce_pc = {D, NH, tile_n, NS, partitions, sinks != nullptr};
+                    ggml_vk_dispatch_pipeline(ctx, subctx, ctx->device->pipeline_flash_attn_split_k_reduce,
+                        {split_buf, sinks_buf, tile_dst}, reduce_pc, {NH, D, tile_n * NS});
+                    ctx->prealloc_split_k_need_sync = true;
+                    ggml_vk_perf_mark_subop(ctx, subctx, "FA_TOP_K_REDUCE (sub-op)");
+                }
                 return true;
             }
         }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -173,7 +173,7 @@ ACC_TYPE perElemOpStoreCol0(const in uint32_t r, const in uint32_t c, const in A
 // Load the slope matrix, indexed by Q's dimension 2.
 ACC_TYPE perElemOpComputeSlope(const in uint32_t r, const in uint32_t c, const in ACC_TYPE elem, const in uint32_t iq2)
 {
-    const uint32_t h = iq2 + (r % p.gqa_ratio);
+    const uint32_t h = iq2 + (r % (p.gqa_ratio & 0xffff));
 
     uint32_t n_head_log2 = p.mask_n_head_log2 & N_LOG2_MASK;
 
@@ -186,32 +186,40 @@ ACC_TYPE perElemOpComputeSlope(const in uint32_t r, const in uint32_t c, const i
 // Load the sink value, indexed by Q's dimension 2.
 ACC_TYPE perElemOpGetSink(const in uint32_t r, const in uint32_t c, const in ACC_TYPE elem, const in uint32_t iq2)
 {
-    const uint32_t h = iq2 + (r % p.gqa_ratio);
+    const uint32_t h = iq2 + (r % (p.gqa_ratio & 0xffff));
 
     return ACC_TYPE(data_s[h]);
 }
 
 uint32_t i, N, KV, split_k_index, Tr, start_j, end_j,
          gqa_iq1, iq2, iq3, rk2, rk3, rv2, rv3, ik2, ik3, iv2, iv3,
-         q_stride, k_stride, v_stride, m_stride;
+         q_stride, k_stride, v_stride, m_stride, gqa_ratio, split_k_num, output_k_num;
+bool partial_output;
 
 void init_indices()
 {
     N = p.N;
     KV = p.KV;
+    gqa_ratio = p.gqa_ratio & 0xffff;
+    split_k_num = p.k_num & 0xffff;
+    output_k_num = p.k_num >> 16;
+    partial_output = output_k_num != 0;
+    if (!partial_output) {
+        output_k_num = split_k_num;
+    }
 
-    if (p.k_num > 1) {
-        if (p.gqa_ratio > 1) {
+    if (split_k_num > 1) {
+        if (gqa_ratio > 1) {
             i = 0;
             // batch and split_k share gl_WorkGroupID.x
-            gqa_iq1 = gl_WorkGroupID.x / p.k_num;
-            split_k_index = gl_WorkGroupID.x % p.k_num;
+            gqa_iq1 = gl_WorkGroupID.x / split_k_num;
+            split_k_index = gl_WorkGroupID.x % split_k_num;
         } else {
             gqa_iq1 = 0;
-            split_k_index = gl_WorkGroupID.x % p.k_num;
-            i = gl_WorkGroupID.x / p.k_num;
+            split_k_index = gl_WorkGroupID.x % split_k_num;
+            i = gl_WorkGroupID.x / split_k_num;
         }
-    } else if (p.gqa_ratio > 1) {
+    } else if (gqa_ratio > 1) {
         i = 0;
         gqa_iq1 = gl_WorkGroupID.x;
         split_k_index = 0;
@@ -228,7 +236,7 @@ void init_indices()
 
     // When not using grouped query attention, all rows share the same iq2, equal to gl_WorkGroupID.y.
     // When using grouped query attention, each workgroup does gqa_ratio consecutive values of iq2.
-    iq2 = gl_WorkGroupID.y * p.gqa_ratio;
+    iq2 = gl_WorkGroupID.y * gqa_ratio;
     iq3 = gl_WorkGroupID.z;
 
     // broadcast factors
@@ -249,14 +257,11 @@ void init_indices()
     // nb?1 are already divided by the type size and are in units of elements.
     // When using grouped query attention, Q is indexed by iq2, so the stride
     // should be nb02 (which is in bytes).
-    q_stride = p.gqa_ratio > 1 ? (p.nb02 / 4) : p.nb01;
+    q_stride = gqa_ratio > 1 ? (p.nb02 / 4) : p.nb01;
     k_stride = p.nb11;
     v_stride = p.nb21;
-    // When using grouped query attention, all rows use the same mask (stride 0).
-    // "p.gqa_ratio >> 16" is just a roundabout way of writing zero
-    // that prevents the compiler from folding the "&" through the select
-    // and breaking the alignment detection.
-    m_stride = (p.gqa_ratio > 1) ? (p.gqa_ratio >> 16) : KV;
+    const uint32_t mask_stride_override = p.gqa_ratio >> 16;
+    m_stride = mask_stride_override != 0 ? mask_stride_override : (gqa_ratio > 1 ? 0 : KV);
 }
 
 // Bias applied to softmax to stay in fp16 range.

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_base.glsl
@@ -260,8 +260,9 @@ void init_indices()
     q_stride = gqa_ratio > 1 ? (p.nb02 / 4) : p.nb01;
     k_stride = p.nb11;
     v_stride = p.nb21;
+    const bool mask_stride_in_split_kv = (p.gqa_ratio & 0x80000000u) != 0;
     const uint32_t mask_stride_override = p.gqa_ratio >> 16;
-    m_stride = mask_stride_override != 0 ? mask_stride_override : (gqa_ratio > 1 ? 0 : KV);
+    m_stride = mask_stride_in_split_kv ? p.split_kv : (mask_stride_override != 0 ? mask_stride_override : (gqa_ratio > 1 ? 0 : KV));
 }
 
 // Bias applied to softmax to stay in fp16 range.

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_cm1.comp
@@ -172,7 +172,7 @@ void main() {
             }
             // Only load if the block is not all zeros
             if (mask_opt_bits != MASK_OPT_ALL_ZERO) {
-                bool nem1_bounds_check = !(p.gqa_ratio > 1) && (p.nem1 % Br) != 0;
+                bool nem1_bounds_check = !(gqa_ratio > 1) && (p.nem1 % Br) != 0;
 
                 float max_mask = NEG_FLT_MAX_OVER_2;
                 [[unroll]] for (uint32_t idx = 0; idx < Bc * Br / 4; idx += gl_WorkGroupSize.x) {
@@ -545,10 +545,10 @@ void main() {
 
     // If there is split_k, then the split_k resolve shader does the final
     // division by L. Store the intermediate O value and per-row m and L values.
-    if (p.k_num > 1) {
-        if (p.gqa_ratio > 1) {
+    if (partial_output || split_k_num > 1) {
+        if (gqa_ratio > 1) {
             // note: O and Q have swapped coord 1,2.
-            uint32_t o_offset = HSV * p.ne1 * (split_k_index + p.k_num * (gqa_iq1 + p.ne2 * iq3)) / 4;
+            uint32_t o_offset = HSV * p.ne1 * (split_k_index + output_k_num * (gqa_iq1 + p.ne2 * iq3)) / 4;
 
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 if (tile_row(r) < N) {
@@ -561,7 +561,7 @@ void main() {
                 }
             }
 
-            o_offset = HSV * p.ne1 * p.k_num * p.ne2 * p.ne3 + p.ne1 * 2 * (split_k_index + p.k_num * (gqa_iq1 + p.ne2 * iq3));
+            o_offset = HSV * p.ne1 * output_k_num * p.ne2 * p.ne3 + p.ne1 * 2 * (split_k_index + output_k_num * (gqa_iq1 + p.ne2 * iq3));
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 if (tile_row(r) < N) {
                     perElemOpStoreCol0(tile_row(r), 0u, ACC_TYPE(Lf[r]), o_offset, iq2, N);
@@ -574,7 +574,7 @@ void main() {
                 const uint global_row = i * Br + row;
 
                 if (global_row < N) {
-                    uint32_t o_offset = HSV * p.ne1 * (split_k_index + p.k_num * (global_row + p.ne2 * iq3)) / 4;
+                    uint32_t o_offset = HSV * p.ne1 * (split_k_index + output_k_num * (global_row + p.ne2 * iq3)) / 4;
 
                     [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {
                         const uint d = d0 + col_tid;
@@ -584,7 +584,7 @@ void main() {
                 }
 
                 if (global_row < N && col_tid == 0) {
-                    uint32_t lm_offset = HSV * p.ne1 * p.k_num * p.ne2 * p.ne3 + p.ne1 * 2 * (split_k_index + p.k_num * (global_row + p.ne2 * iq3));
+                    uint32_t lm_offset = HSV * p.ne1 * output_k_num * p.ne2 * p.ne3 + p.ne1 * 2 * (split_k_index + output_k_num * (global_row + p.ne2 * iq3));
                     data_o[lm_offset + iq2] = D_TYPE(Lf[r]);
                     data_o[lm_offset + p.ne1 + iq2] = D_TYPE(Mf[r]);
                 }
@@ -633,7 +633,7 @@ void main() {
 
     uint32_t o_offset = (gqa_iq1*p.ne1*HSV + iq3*p.ne2*p.ne1*HSV) / 4;
 
-    if (p.gqa_ratio > 1) {
+    if (gqa_ratio > 1) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             if (tile_row(r) < N) {
                 [[unroll]] for (uint32_t d0 = 0; d0 < HSV / 4; d0 += threads_per_rowgroup) {

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k.comp
@@ -37,6 +37,8 @@ layout(push_constant) uniform Parameters {
     uint nb3;
     float scale;
     uint has_sinks;
+    uint profile_stage;
+    uint split_mode;
 } p;
 
 // Shape constants pinned by the dispatch gate in ggml_vk_flash_attn_top_k: DeepSeek V4

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
@@ -58,10 +58,9 @@ const float MASK_NEG_INF = -65500.0;
 shared uint key_idx[KEYS_PER_BLOCK];
 shared f16vec4 q_sh[HEADS_PER_GROUP * QK_STRIDE];
 shared f16vec4 k_sh[KEYS_PER_BLOCK * QK_STRIDE];
-shared vec4 score_sh[KEYS_PER_BLOCK * SCORE_STRIDE];
+shared vec4 matrix_sh[KEYS_PER_BLOCK * SCORE_STRIDE];
 shared f16vec4 p_sh[HEADS_PER_GROUP * P_STRIDE];
 shared f16vec4 v_sh[KEYS_PER_BLOCK * V_STRIDE];
-shared vec4 pv_sh[HEADS_PER_GROUP * PV_STRIDE];
 shared float old_scale_sh[HEADS_PER_GROUP];
 shared float row_max_sh[HEADS_PER_GROUP];
 shared float row_sum_sh[HEADS_PER_GROUP];
@@ -142,7 +141,7 @@ void main() {
 
         const uint score_key_chunk = gl_SubgroupID % (KEYS_PER_BLOCK / TILE);
         const uint score_head_tile = gl_SubgroupID / (KEYS_PER_BLOCK / TILE);
-        coopMatStore(scores, score_sh,
+        coopMatStore(scores, matrix_sh,
             score_key_chunk * TILE * SCORE_STRIDE + score_head_tile * (TILE / 4),
             SCORE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
         barrier();
@@ -159,7 +158,7 @@ void main() {
                 const uint key_local = softmax_lane + i * (SUBGROUP_SIZE / 4);
                 const uint key = key_idx[key_local];
                 const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
-                const float score = float(score_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
+                const float score = float(matrix_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
                 block_max = mask < MASK_NEG_INF ? block_max : max(block_max, score);
             }
             [[unroll]] for (uint delta = 1; delta < SUBGROUP_SIZE / 4; delta *= 2) {
@@ -177,7 +176,7 @@ void main() {
                 const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
                 float weight = 0.0;
                 if (mask >= MASK_NEG_INF) {
-                    const float score = float(score_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
+                    const float score = float(matrix_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
                     weight = exp(score - new_max);
                     block_sum += weight;
                 }
@@ -205,6 +204,14 @@ void main() {
             continue;
         }
 
+        coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> pmats[KEYS_PER_BLOCK / TILE];
+        [[unroll]] for (uint key_chunk = 0; key_chunk < KEYS_PER_BLOCK / TILE; ++key_chunk) {
+            const uint pv_head_tile = gl_SubgroupID / (DIMS_PER_BLOCK / TILE);
+            coopMatLoad(pmats[key_chunk], p_sh,
+                pv_head_tile * TILE * P_STRIDE + key_chunk * (TILE / 4),
+                P_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+        }
+
         [[unroll]] for (uint dim_base = 0; dim_base < HEAD_SIZE; dim_base += DIMS_PER_BLOCK) {
             [[unroll]] for (uint idx = tid; idx < KEYS_PER_BLOCK * (DIMS_PER_BLOCK / 4); idx += WORKGROUP_SIZE) {
                 const uint key_local = idx / (DIMS_PER_BLOCK / 4);
@@ -221,22 +228,18 @@ void main() {
 
             coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator> pv =
                 coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator>(0.0);
-            coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> pmat;
             coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseB> vmat;
 
             const uint pv_head_tile = gl_SubgroupID / (DIMS_PER_BLOCK / TILE);
             const uint pv_dim_tile = gl_SubgroupID % (DIMS_PER_BLOCK / TILE);
             [[unroll]] for (uint key_chunk = 0; key_chunk < KEYS_PER_BLOCK / TILE; ++key_chunk) {
-                coopMatLoad(pmat, p_sh,
-                    pv_head_tile * TILE * P_STRIDE + key_chunk * (TILE / 4),
-                    P_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
                 coopMatLoad(vmat, v_sh,
                     key_chunk * TILE * V_STRIDE + pv_dim_tile * (TILE / 4),
                     V_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
-                pv = coopMatMulAdd(pmat, vmat, pv);
+                pv = coopMatMulAdd(pmats[key_chunk], vmat, pv);
             }
 
-            coopMatStore(pv, pv_sh,
+            coopMatStore(pv, matrix_sh,
                 pv_head_tile * TILE * PV_STRIDE + pv_dim_tile * (TILE / 4), PV_STRIDE,
                 gl_CooperativeMatrixLayoutRowMajor);
             barrier();
@@ -246,7 +249,7 @@ void main() {
                 const uint head_local = out_idx / HEAD_SIZE;
                 const uint dim = out_idx % HEAD_SIZE;
                 if (dim >= dim_base && dim < dim_base + DIMS_PER_BLOCK) {
-                    accum[i] += pv_sh[head_local * PV_STRIDE + (dim - dim_base) / 4][dim % 4];
+                    accum[i] += matrix_sh[head_local * PV_STRIDE + (dim - dim_base) / 4][dim % 4];
                 }
             }
             barrier();

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
@@ -39,6 +39,8 @@ layout(push_constant) uniform Parameters {
     uint nb3;
     float scale;
     uint has_sinks;
+    uint profile_stage;
+    uint split_mode;
 } p;
 
 const uint TILE = 16;
@@ -71,7 +73,7 @@ void main() {
     const uint stream = gl_WorkGroupID.z;
     const uint mask_base = stream * p.nbm3 + token * p.nbm1;
     const uint top_base = stream * p.nbt3 + token * p.nbt1;
-    const uint total_keys = p.n_kv_raw + p.n_top_k;
+    const uint total_keys = p.split_mode != 0 ? p.n_top_k : p.n_kv_raw + p.n_top_k;
 
     float accum[HEADS_PER_GROUP * HEAD_SIZE / WORKGROUP_SIZE];
     [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
@@ -88,10 +90,11 @@ void main() {
         if (tid < KEYS_PER_BLOCK) {
             const uint selected = kb + tid;
             uint key = p.n_kv;
-            if (selected < p.n_kv_raw) {
+            if (p.split_mode == 0 && selected < p.n_kv_raw) {
                 key = selected;
             } else if (selected < total_keys) {
-                const int compressed = data_top[top_base + selected - p.n_kv_raw];
+                const uint top_pos = p.split_mode != 0 ? selected : selected - p.n_kv_raw;
+                const int compressed = data_top[top_base + top_pos];
                 if (compressed >= 0 && uint(compressed) < p.n_kv - p.n_kv_raw) {
                     key = p.n_kv_raw + uint(compressed);
                 }
@@ -144,6 +147,10 @@ void main() {
             SCORE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
         barrier();
 
+        if (p.profile_stage == 1) {
+            continue;
+        }
+
         {
             const uint head_local = tid / (SUBGROUP_SIZE / 4);
             const uint softmax_lane = tid % (SUBGROUP_SIZE / 4);
@@ -194,6 +201,10 @@ void main() {
             accum[i] *= old_scale_sh[head_local];
         }
 
+        if (p.profile_stage == 2) {
+            continue;
+        }
+
         [[unroll]] for (uint dim_base = 0; dim_base < HEAD_SIZE; dim_base += DIMS_PER_BLOCK) {
             [[unroll]] for (uint idx = tid; idx < KEYS_PER_BLOCK * (DIMS_PER_BLOCK / 4); idx += WORKGROUP_SIZE) {
                 const uint key_local = idx / (DIMS_PER_BLOCK / 4);
@@ -242,7 +253,7 @@ void main() {
         }
     }
 
-    if (p.has_sinks != 0 && tid < HEADS_PER_GROUP) {
+    if (p.split_mode == 0 && p.has_sinks != 0 && tid < HEADS_PER_GROUP) {
         const float sink = data_s[head_base + tid];
         const float new_max = max(row_max_sh[tid], sink);
         const float old_scale = row_sum_sh[tid] == 0.0 ? 0.0 : exp(row_max_sh[tid] - new_max);
@@ -252,7 +263,7 @@ void main() {
     }
     barrier();
 
-    if (p.has_sinks != 0) {
+    if (p.split_mode == 0 && p.has_sinks != 0) {
         [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
             const uint out_idx = tid + i * WORKGROUP_SIZE;
             accum[i] *= old_scale_sh[out_idx / HEAD_SIZE];
@@ -262,8 +273,19 @@ void main() {
         const uint out_idx = tid + i * WORKGROUP_SIZE;
         const uint head_local = out_idx / HEAD_SIZE;
         const uint dim = out_idx % HEAD_SIZE;
-        const uint dst_base = stream * p.nb3 + token * p.nb2 + (head_base + head_local) * p.nb1;
-        const float inv_sum = row_sum_sh[head_local] == 0.0 ? 0.0 : 1.0 / row_sum_sh[head_local];
-        data_dst[dst_base + dim] = accum[i] * inv_sum;
+        if (p.split_mode != 0) {
+            const uint part_idx = 1;
+            const uint matrix_base = HEAD_SIZE * p.n_head * (part_idx + 2 * (token + p.n_batch * stream));
+            const uint lm_base = HEAD_SIZE * p.n_head * p.n_batch * 2 + p.n_head * 2 * (part_idx + 2 * (token + p.n_batch * stream));
+            data_dst[matrix_base + (head_base + head_local) * HEAD_SIZE + dim] = accum[i];
+            if (dim == 0) {
+                data_dst[lm_base + head_base + head_local] = row_sum_sh[head_local];
+                data_dst[lm_base + p.n_head + head_base + head_local] = row_max_sh[head_local];
+            }
+        } else {
+            const uint dst_base = stream * p.nb3 + token * p.nb2 + (head_base + head_local) * p.nb1;
+            const float inv_sum = row_sum_sh[head_local] == 0.0 ? 0.0 : 1.0 / row_sum_sh[head_local];
+            data_dst[dst_base + dim] = accum[i] * inv_sum;
+        }
     }
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
@@ -56,11 +56,10 @@ const uint PV_STRIDE = DIMS_PER_BLOCK / 4;
 const float MASK_NEG_INF = -65500.0;
 
 shared uint key_idx[KEYS_PER_BLOCK];
-shared f16vec4 q_sh[HEADS_PER_GROUP * QK_STRIDE];
-shared f16vec4 k_sh[KEYS_PER_BLOCK * QK_STRIDE];
+shared float key_mask[KEYS_PER_BLOCK];
+shared f16vec4 q_p_sh[HEADS_PER_GROUP * P_STRIDE];
+shared f16vec4 k_v_sh[KEYS_PER_BLOCK * V_STRIDE];
 shared vec4 matrix_sh[KEYS_PER_BLOCK * SCORE_STRIDE];
-shared f16vec4 p_sh[HEADS_PER_GROUP * P_STRIDE];
-shared f16vec4 v_sh[KEYS_PER_BLOCK * V_STRIDE];
 shared float old_scale_sh[HEADS_PER_GROUP];
 shared float row_max_sh[HEADS_PER_GROUP];
 shared float row_sum_sh[HEADS_PER_GROUP];
@@ -99,6 +98,7 @@ void main() {
                 }
             }
             key_idx[tid] = key;
+            key_mask[tid] = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
         }
         barrier();
 
@@ -117,23 +117,23 @@ void main() {
                     const uint offset = stream * p.nbk3 + key * p.nbk1 + d + d4 * 4;
                     value = f16vec4(data_k[offset], data_k[offset + 1], data_k[offset + 2], data_k[offset + 3]);
                 }
-                k_sh[key_local * QK_STRIDE + d4] = value;
+                k_v_sh[key_local * QK_STRIDE + d4] = value;
             }
             if (tid < HEADS_PER_GROUP * (TILE / 4)) {
                 const uint head_local = tid / (TILE / 4);
                 const uint d4 = tid % (TILE / 4);
                 const uint head = head_base + head_local;
                 const uint offset = stream * p.nbq3 + head * p.nbq2 + token * p.nbq1 + d + d4 * 4;
-                q_sh[head_local * QK_STRIDE + d4] = f16vec4(
+                q_p_sh[head_local * QK_STRIDE + d4] = f16vec4(
                     data_q[offset], data_q[offset + 1], data_q[offset + 2], data_q[offset + 3]);
             }
             barrier();
 
             const uint key_chunk = gl_SubgroupID % (KEYS_PER_BLOCK / TILE);
             const uint head_tile = gl_SubgroupID / (KEYS_PER_BLOCK / TILE);
-            coopMatLoad(kmat, k_sh, key_chunk * TILE * QK_STRIDE,
+            coopMatLoad(kmat, k_v_sh, key_chunk * TILE * QK_STRIDE,
                 QK_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
-            coopMatLoad(qmat, q_sh, head_tile * TILE * QK_STRIDE,
+            coopMatLoad(qmat, q_p_sh, head_tile * TILE * QK_STRIDE,
                 QK_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
             scores = coopMatMulAdd(kmat, qmat, scores);
             barrier();
@@ -156,8 +156,7 @@ void main() {
             float block_max = uintBitsToFloat(0xff800000);
             [[unroll]] for (uint i = 0; i < KEYS_PER_BLOCK / (SUBGROUP_SIZE / 4); ++i) {
                 const uint key_local = softmax_lane + i * (SUBGROUP_SIZE / 4);
-                const uint key = key_idx[key_local];
-                const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
+                const float mask = key_mask[key_local];
                 const float score = float(matrix_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
                 block_max = mask < MASK_NEG_INF ? block_max : max(block_max, score);
             }
@@ -172,15 +171,14 @@ void main() {
             float block_sum = 0.0;
             [[unroll]] for (uint i = 0; i < KEYS_PER_BLOCK / (SUBGROUP_SIZE / 4); ++i) {
                 const uint key_local = softmax_lane + i * (SUBGROUP_SIZE / 4);
-                const uint key = key_idx[key_local];
-                const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
+                const float mask = key_mask[key_local];
                 float weight = 0.0;
                 if (mask >= MASK_NEG_INF) {
                     const float score = float(matrix_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
                     weight = exp(score - new_max);
                     block_sum += weight;
                 }
-                p_sh[head_local * P_STRIDE + key_local / 4][key_local % 4] = float16_t(weight);
+                q_p_sh[head_local * P_STRIDE + key_local / 4][key_local % 4] = float16_t(weight);
             }
             [[unroll]] for (uint delta = 1; delta < SUBGROUP_SIZE / 4; delta *= 2) {
                 block_sum += subgroupShuffleXor(block_sum, delta);
@@ -207,7 +205,7 @@ void main() {
         coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> pmats[KEYS_PER_BLOCK / TILE];
         [[unroll]] for (uint key_chunk = 0; key_chunk < KEYS_PER_BLOCK / TILE; ++key_chunk) {
             const uint pv_head_tile = gl_SubgroupID / (DIMS_PER_BLOCK / TILE);
-            coopMatLoad(pmats[key_chunk], p_sh,
+            coopMatLoad(pmats[key_chunk], q_p_sh,
                 pv_head_tile * TILE * P_STRIDE + key_chunk * (TILE / 4),
                 P_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
         }
@@ -222,7 +220,7 @@ void main() {
                     const uint offset = stream * p.nbk3 + key * p.nbk1 + dim_base + d4 * 4;
                     value = f16vec4(data_k[offset], data_k[offset + 1], data_k[offset + 2], data_k[offset + 3]);
                 }
-                v_sh[key_local * V_STRIDE + d4] = value;
+                k_v_sh[key_local * V_STRIDE + d4] = value;
             }
             barrier();
 
@@ -233,7 +231,7 @@ void main() {
             const uint pv_head_tile = gl_SubgroupID / (DIMS_PER_BLOCK / TILE);
             const uint pv_dim_tile = gl_SubgroupID % (DIMS_PER_BLOCK / TILE);
             [[unroll]] for (uint key_chunk = 0; key_chunk < KEYS_PER_BLOCK / TILE; ++key_chunk) {
-                coopMatLoad(vmat, v_sh,
+                coopMatLoad(vmat, k_v_sh,
                     key_chunk * TILE * V_STRIDE + pv_dim_tile * (TILE / 4),
                     V_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
                 pv = coopMatMulAdd(pmats[key_chunk], vmat, pv);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn_top_k_cm.comp
@@ -1,0 +1,269 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_shuffle : require
+
+layout(constant_id = 0) const uint WORKGROUP_SIZE = 512;
+layout(constant_id = 1) const uint SUBGROUP_SIZE = 64;
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly  buffer QBuf    { float     data_q[];   };
+layout(binding = 1) readonly  buffer KBuf    { float16_t data_k[];   };
+layout(binding = 2) readonly  buffer MaskBuf { float16_t data_m[];   };
+layout(binding = 3) readonly  buffer SinkBuf { float     data_s[];   };
+layout(binding = 4) readonly  buffer TopBuf  { int       data_top[]; };
+layout(binding = 5) writeonly buffer DstBuf  { float     data_dst[]; };
+
+layout(push_constant) uniform Parameters {
+    uint n_batch;
+    uint n_kv;
+    uint n_kv_raw;
+    uint n_top_k;
+    uint n_head;
+    uint nbq1;
+    uint nbq2;
+    uint nbq3;
+    uint nbk1;
+    uint nbk3;
+    uint nbm1;
+    uint nbm3;
+    uint nbt1;
+    uint nbt3;
+    uint nb1;
+    uint nb2;
+    uint nb3;
+    float scale;
+    uint has_sinks;
+} p;
+
+const uint TILE = 16;
+const uint HEAD_SIZE = 512;
+const uint HEADS_PER_GROUP = 32;
+const uint KEYS_PER_BLOCK = 64;
+const uint DIMS_PER_BLOCK = 64;
+const uint QK_STRIDE = TILE / 4 + 2;
+const uint SCORE_STRIDE = HEADS_PER_GROUP / 4 + 1;
+const uint P_STRIDE = KEYS_PER_BLOCK / 4 + 2;
+const uint V_STRIDE = DIMS_PER_BLOCK / 4 + 2;
+const uint PV_STRIDE = DIMS_PER_BLOCK / 4;
+const float MASK_NEG_INF = -65500.0;
+
+shared uint key_idx[KEYS_PER_BLOCK];
+shared f16vec4 q_sh[HEADS_PER_GROUP * QK_STRIDE];
+shared f16vec4 k_sh[KEYS_PER_BLOCK * QK_STRIDE];
+shared vec4 score_sh[KEYS_PER_BLOCK * SCORE_STRIDE];
+shared f16vec4 p_sh[HEADS_PER_GROUP * P_STRIDE];
+shared f16vec4 v_sh[KEYS_PER_BLOCK * V_STRIDE];
+shared vec4 pv_sh[HEADS_PER_GROUP * PV_STRIDE];
+shared float old_scale_sh[HEADS_PER_GROUP];
+shared float row_max_sh[HEADS_PER_GROUP];
+shared float row_sum_sh[HEADS_PER_GROUP];
+
+void main() {
+    const uint tid = gl_LocalInvocationIndex;
+    const uint token = gl_WorkGroupID.x;
+    const uint head_base = gl_WorkGroupID.y * HEADS_PER_GROUP;
+    const uint stream = gl_WorkGroupID.z;
+    const uint mask_base = stream * p.nbm3 + token * p.nbm1;
+    const uint top_base = stream * p.nbt3 + token * p.nbt1;
+    const uint total_keys = p.n_kv_raw + p.n_top_k;
+
+    float accum[HEADS_PER_GROUP * HEAD_SIZE / WORKGROUP_SIZE];
+    [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
+        accum[i] = 0.0;
+    }
+
+    if (tid < HEADS_PER_GROUP) {
+        row_max_sh[tid] = uintBitsToFloat(0xff800000);
+        row_sum_sh[tid] = 0.0;
+    }
+    barrier();
+
+    for (uint kb = 0; kb < total_keys; kb += KEYS_PER_BLOCK) {
+        if (tid < KEYS_PER_BLOCK) {
+            const uint selected = kb + tid;
+            uint key = p.n_kv;
+            if (selected < p.n_kv_raw) {
+                key = selected;
+            } else if (selected < total_keys) {
+                const int compressed = data_top[top_base + selected - p.n_kv_raw];
+                if (compressed >= 0 && uint(compressed) < p.n_kv - p.n_kv_raw) {
+                    key = p.n_kv_raw + uint(compressed);
+                }
+            }
+            key_idx[tid] = key;
+        }
+        barrier();
+
+        coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator> scores =
+            coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator>(0.0);
+        coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> kmat;
+        coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseB> qmat;
+
+        [[unroll]] for (uint d = 0; d < HEAD_SIZE; d += TILE) {
+            if (tid < KEYS_PER_BLOCK * (TILE / 4)) {
+                const uint key_local = tid / (TILE / 4);
+                const uint d4 = tid % (TILE / 4);
+                const uint key = key_idx[key_local];
+                f16vec4 value = f16vec4(0.0);
+                if (key < p.n_kv) {
+                    const uint offset = stream * p.nbk3 + key * p.nbk1 + d + d4 * 4;
+                    value = f16vec4(data_k[offset], data_k[offset + 1], data_k[offset + 2], data_k[offset + 3]);
+                }
+                k_sh[key_local * QK_STRIDE + d4] = value;
+            }
+            if (tid < HEADS_PER_GROUP * (TILE / 4)) {
+                const uint head_local = tid / (TILE / 4);
+                const uint d4 = tid % (TILE / 4);
+                const uint head = head_base + head_local;
+                const uint offset = stream * p.nbq3 + head * p.nbq2 + token * p.nbq1 + d + d4 * 4;
+                q_sh[head_local * QK_STRIDE + d4] = f16vec4(
+                    data_q[offset], data_q[offset + 1], data_q[offset + 2], data_q[offset + 3]);
+            }
+            barrier();
+
+            const uint key_chunk = gl_SubgroupID % (KEYS_PER_BLOCK / TILE);
+            const uint head_tile = gl_SubgroupID / (KEYS_PER_BLOCK / TILE);
+            coopMatLoad(kmat, k_sh, key_chunk * TILE * QK_STRIDE,
+                QK_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+            coopMatLoad(qmat, q_sh, head_tile * TILE * QK_STRIDE,
+                QK_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
+            scores = coopMatMulAdd(kmat, qmat, scores);
+            barrier();
+        }
+
+        const uint score_key_chunk = gl_SubgroupID % (KEYS_PER_BLOCK / TILE);
+        const uint score_head_tile = gl_SubgroupID / (KEYS_PER_BLOCK / TILE);
+        coopMatStore(scores, score_sh,
+            score_key_chunk * TILE * SCORE_STRIDE + score_head_tile * (TILE / 4),
+            SCORE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+        barrier();
+
+        {
+            const uint head_local = tid / (SUBGROUP_SIZE / 4);
+            const uint softmax_lane = tid % (SUBGROUP_SIZE / 4);
+            float block_max = uintBitsToFloat(0xff800000);
+            [[unroll]] for (uint i = 0; i < KEYS_PER_BLOCK / (SUBGROUP_SIZE / 4); ++i) {
+                const uint key_local = softmax_lane + i * (SUBGROUP_SIZE / 4);
+                const uint key = key_idx[key_local];
+                const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
+                const float score = float(score_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
+                block_max = mask < MASK_NEG_INF ? block_max : max(block_max, score);
+            }
+            [[unroll]] for (uint delta = 1; delta < SUBGROUP_SIZE / 4; delta *= 2) {
+                block_max = max(block_max, subgroupShuffleXor(block_max, delta));
+            }
+
+            const float old_row_max = row_max_sh[head_local];
+            const float old_row_sum = row_sum_sh[head_local];
+            const float new_max = max(old_row_max, block_max);
+            const float old_scale = old_row_sum == 0.0 ? 0.0 : exp(old_row_max - new_max);
+            float block_sum = 0.0;
+            [[unroll]] for (uint i = 0; i < KEYS_PER_BLOCK / (SUBGROUP_SIZE / 4); ++i) {
+                const uint key_local = softmax_lane + i * (SUBGROUP_SIZE / 4);
+                const uint key = key_idx[key_local];
+                const float mask = key < p.n_kv ? float(data_m[mask_base + key]) : uintBitsToFloat(0xff800000);
+                float weight = 0.0;
+                if (mask >= MASK_NEG_INF) {
+                    const float score = float(score_sh[key_local * SCORE_STRIDE + head_local / 4][head_local % 4]) * p.scale + mask;
+                    weight = exp(score - new_max);
+                    block_sum += weight;
+                }
+                p_sh[head_local * P_STRIDE + key_local / 4][key_local % 4] = float16_t(weight);
+            }
+            [[unroll]] for (uint delta = 1; delta < SUBGROUP_SIZE / 4; delta *= 2) {
+                block_sum += subgroupShuffleXor(block_sum, delta);
+            }
+
+            if (softmax_lane == 0) {
+                row_sum_sh[head_local] = old_row_sum * old_scale + block_sum;
+                row_max_sh[head_local] = new_max;
+                old_scale_sh[head_local] = old_scale;
+            }
+        }
+        barrier();
+
+        [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
+            const uint out_idx = tid + i * WORKGROUP_SIZE;
+            const uint head_local = out_idx / HEAD_SIZE;
+            accum[i] *= old_scale_sh[head_local];
+        }
+
+        [[unroll]] for (uint dim_base = 0; dim_base < HEAD_SIZE; dim_base += DIMS_PER_BLOCK) {
+            [[unroll]] for (uint idx = tid; idx < KEYS_PER_BLOCK * (DIMS_PER_BLOCK / 4); idx += WORKGROUP_SIZE) {
+                const uint key_local = idx / (DIMS_PER_BLOCK / 4);
+                const uint d4 = idx % (DIMS_PER_BLOCK / 4);
+                const uint key = key_idx[key_local];
+                f16vec4 value = f16vec4(0.0);
+                if (key < p.n_kv) {
+                    const uint offset = stream * p.nbk3 + key * p.nbk1 + dim_base + d4 * 4;
+                    value = f16vec4(data_k[offset], data_k[offset + 1], data_k[offset + 2], data_k[offset + 3]);
+                }
+                v_sh[key_local * V_STRIDE + d4] = value;
+            }
+            barrier();
+
+            coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator> pv =
+                coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator>(0.0);
+            coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> pmat;
+            coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseB> vmat;
+
+            const uint pv_head_tile = gl_SubgroupID / (DIMS_PER_BLOCK / TILE);
+            const uint pv_dim_tile = gl_SubgroupID % (DIMS_PER_BLOCK / TILE);
+            [[unroll]] for (uint key_chunk = 0; key_chunk < KEYS_PER_BLOCK / TILE; ++key_chunk) {
+                coopMatLoad(pmat, p_sh,
+                    pv_head_tile * TILE * P_STRIDE + key_chunk * (TILE / 4),
+                    P_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+                coopMatLoad(vmat, v_sh,
+                    key_chunk * TILE * V_STRIDE + pv_dim_tile * (TILE / 4),
+                    V_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+                pv = coopMatMulAdd(pmat, vmat, pv);
+            }
+
+            coopMatStore(pv, pv_sh,
+                pv_head_tile * TILE * PV_STRIDE + pv_dim_tile * (TILE / 4), PV_STRIDE,
+                gl_CooperativeMatrixLayoutRowMajor);
+            barrier();
+
+            [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
+                const uint out_idx = tid + i * WORKGROUP_SIZE;
+                const uint head_local = out_idx / HEAD_SIZE;
+                const uint dim = out_idx % HEAD_SIZE;
+                if (dim >= dim_base && dim < dim_base + DIMS_PER_BLOCK) {
+                    accum[i] += pv_sh[head_local * PV_STRIDE + (dim - dim_base) / 4][dim % 4];
+                }
+            }
+            barrier();
+        }
+    }
+
+    if (p.has_sinks != 0 && tid < HEADS_PER_GROUP) {
+        const float sink = data_s[head_base + tid];
+        const float new_max = max(row_max_sh[tid], sink);
+        const float old_scale = row_sum_sh[tid] == 0.0 ? 0.0 : exp(row_max_sh[tid] - new_max);
+        row_sum_sh[tid] = row_sum_sh[tid] * old_scale + exp(sink - new_max);
+        row_max_sh[tid] = new_max;
+        old_scale_sh[tid] = old_scale;
+    }
+    barrier();
+
+    if (p.has_sinks != 0) {
+        [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
+            const uint out_idx = tid + i * WORKGROUP_SIZE;
+            accum[i] *= old_scale_sh[out_idx / HEAD_SIZE];
+        }
+    }
+    [[unroll]] for (uint i = 0; i < accum.length(); ++i) {
+        const uint out_idx = tid + i * WORKGROUP_SIZE;
+        const uint head_local = out_idx / HEAD_SIZE;
+        const uint dim = out_idx % HEAD_SIZE;
+        const uint dst_base = stream * p.nb3 + token * p.nb2 + (head_base + head_local) * p.nb1;
+        const float inv_sum = row_sum_sh[head_local] == 0.0 ? 0.0 : 1.0 / row_sum_sh[head_local];
+        data_dst[dst_base + dim] = accum[i] * inv_sum;
+    }
+}

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -806,6 +806,9 @@ void process_shaders() {
     string_to_spv("lightning_indexer_decode_cm_f16", "lightning_indexer_decode_cm.comp", {});
 #endif
     string_to_spv("flash_attn_top_k_f16", "flash_attn_top_k.comp", {});
+#if defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
+    string_to_spv("flash_attn_top_k_cm_f16", "flash_attn_top_k_cm.comp", {});
+#endif
     string_to_spv("flash_attn_gather_f16", "flash_attn_gather.comp", {});
     string_to_spv("dsv4_hc_pre_f32",  "dsv4_hc_pre.comp",  {});
     string_to_spv("dsv4_hc_comb_f32", "dsv4_hc_comb.comp", {});

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10344,7 +10344,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
             test_cases.emplace_back(new test_flash_attn_ext_top_k(kv, nb, 1024, 512, false));
         }
     }
-    test_cases.emplace_back(new test_flash_attn_ext_top_k(19200, 2048, 2304, 512, false));
+    // PP2048 compressed-K rows for source context depths 32k through 512k.
+    for (int kv : { 11008, 19200, 35584, 68352, 133888 }) {
+        test_cases.emplace_back(new test_flash_attn_ext_top_k(kv, 2048, 2304, 512, false));
+    }
 
     return test_cases;
 }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9907,6 +9907,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext_top_k( 768,  64,  64, 128, true));
     test_cases.emplace_back(new test_flash_attn_ext_top_k(1024,  64,  65, 128, false));
     test_cases.emplace_back(new test_flash_attn_ext_top_k(4096, 128, 256, 512, false));
+    test_cases.emplace_back(new test_flash_attn_ext_top_k(4096, 257, 256, 512, false));
 
     for (int kv : { 1, 7, 8, 63, 64, 65 }) {
         for (ggml_type type_K : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_BF16, GGML_TYPE_Q8_0, GGML_TYPE_Q5_1, GGML_TYPE_Q5_0, GGML_TYPE_Q4_1, GGML_TYPE_Q4_0}) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9905,6 +9905,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext_top_k( 512,  4,  64, 128, false));
     test_cases.emplace_back(new test_flash_attn_ext_top_k( 768,  64,  64, 128, false));
     test_cases.emplace_back(new test_flash_attn_ext_top_k( 768,  64,  64, 128, true));
+    test_cases.emplace_back(new test_flash_attn_ext_top_k(1024,  64,  65, 128, false));
     test_cases.emplace_back(new test_flash_attn_ext_top_k(4096, 128, 256, 512, false));
 
     for (int kv : { 1, 7, 8, 63, 64, 65 }) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10343,6 +10343,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
             test_cases.emplace_back(new test_flash_attn_ext_top_k(kv, nb, 1024, 512, false));
         }
     }
+    test_cases.emplace_back(new test_flash_attn_ext_top_k(19200, 2048, 2304, 512, false));
 
     return test_cases;
 }


### PR DESCRIPTION
I will be very honest: I did NOT review the code and this was entirely written by AI. What I DID do was the following:

1. Make sure the speed improvements are real in micro benches
2. Make sure the speed improvements are real in llama-bench
3. Make sure the speed improvements are real in llama-server
4. Make sure all FLASH_ATTN_EXT unit tests are still passing
5. Make sure llama-server is still coherent.
6. Write this PR description myself :)

These changes have only been tested with DeepSeek v4 Flash in combination with Strix Halo 395.

As mentioned in the title, the improvement amounted to an improvement from 119 to 210 tokens/sec at a context depth of 32k. A ubatch of 2048 was used in all testing. Furthermore, the time spent on the sparse attention plateaus quickly, meaning the prefill speed stays very flat (Note: Lightning indexer does scale with context length, so prefill falloff is still expected, it's simply much less extreme):

  Depth  Micro-bench at simulated context depth
  32k      108.07 ms
  64k      109.11 ms
  128k    116.92 ms
  256k    116.93 ms
  512k    116.27 ms

Each commit individually works, and we can choose to review things individually if that's preferred. I can reopen additional PRs with individual commits. A quick summary of the 5 commits:

1. The first commit introduces a coopmat sparse attention kernel
2. The second commit introduces a split attention mechanism. Each query attends to a contiguous block of keys as well as 512 keys selected by the lightning indexer. The existing regular dense attention is used to attend to the contiguous block of keys, as this is already highly optimized code. The coopmat sparse attention kernel is then used to attend to the non-contiguous 512 keys. Lastly, the results are combined.
3. The third commit tiles the scratch buffer to reduce the size of this new buffer that was introduced as part of commit number 2
4. Micro improvement
5. Micro improvement

What we probably still need to do:

1. Remove the .md scratch pad that I was using with my agent
2. Verify where the cutoff should be to transition from the purely dense attention kernel to the dense + sparse split. Since the new kernel has been improved, the cutoff where the switch is beneficial has probably also changed.

The reason why I am opening this PR as-is, is to gather some initial feedback so we can get the ball rolling and work out a plan on how to get from this to mergeable PRs. Let me know what you think or if you prefer a different approach.