### PR TITLE
vulkan: parallelize DSV4 Lightning Indexer prefill

### DIFF
--- a/docs/development/DSV4-vulkan-lightning-indexer-progress.md
+++ b/docs/development/DSV4-vulkan-lightning-indexer-progress.md
@@ -1,0 +1,158 @@
+# DeepSeek V4 Vulkan Lightning Indexer progress
+
+This is a restart note for the Strix Halo Lightning Indexer optimization. It is a development scratch pad and can be removed before the final PR.
+
+## Repository state
+
+- Main repository: `/home/jaap/Projects/git/llama.cpp`
+- Optimization worktree: `/tmp/llama-strix-beta-bench`
+- Branch: `strix-halo-vulkan-lightning-indexer`
+- Base commit: `316c72ee9eab590f5891089d3b6bfc0d01d00d19`
+- Base branch: Nathan's `strix-halo-vulkan-beta`
+- Decode microbench work is stored in the main worktree as `stash@{0}: On strix-halo-vulkan: wip: DSV4 decode microbench depth matrix`.
+- The Indexer changes are uncommitted. Do not commit without explicit user approval. An assisted commit needs an `Assisted-by:` trailer.
+- Do not run builds and GPU benchmarks together. The APU shares its power and memory-bandwidth budget.
+- GPU commands need sandbox escalation.
+
+## Objective and result
+
+After sparse prefill attention was flattened, the context-dependent Lightning Indexer became the next prefill bottleneck. The old cooperative-matrix shader used one wave64 subgroup per workgroup, processed one 16-key tile, and loaded one query head at a time.
+
+The new wide pipeline uses eight wave64 subgroups per workgroup. Each subgroup processes a separate 16-key tile, so one workgroup covers 128 keys. It stages four query heads and their weights together, reuses them across all eight subgroups, and uses subgroup-scoped synchronization between cooperative-matrix result stores. A workgroup barrier remains between four-head groups because all subgroups reuse the shared query storage.
+
+The optimized shader requires 512 workgroup invocations and 64 KiB shared memory. Pipeline creation is capability-based. Devices without those limits use a one-wave, one-head cooperative-matrix specialization. The scalar implementation remains the fallback when cooperative matrices are unavailable. The decode-specific cooperative-matrix pipeline is unchanged.
+
+At the 32k-equivalent prefill microbench shape:
+
+| Version | Time per layer | Throughput |
+| --- | ---: | ---: |
+| Baseline | 50.51 ms | 5.83 TFLOPS |
+| Optimized | 31.81 ms | 9.25 TFLOPS |
+
+This is a 37.0% reduction in Lightning Indexer kernel time.
+
+The canonical 32k llama-bench improved from 209.45 to 216.32 tokens/s. Total Vulkan time fell from 9.73729 to 9.42448 seconds. Total Lightning Indexer time fell from 1.11860 to 0.697276 seconds. Sparse attention and top-K were effectively unchanged.
+
+## Changed files
+
+- `ggml/src/ggml-vulkan/vulkan-shaders/lightning_indexer_cm.comp`: parameterizes the shader, adds the eight-wave four-head implementation, and remains usable for the small fallback.
+- `ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp`: generates wide `N_WAVES=8`, `HEADS_PER_TILE=4` and small `N_WAVES=1`, `HEADS_PER_TILE=1` variants.
+- `ggml/src/ggml-vulkan/ggml-vulkan.cpp`: creates and selects the capability-gated wide pipeline and the small cooperative-matrix fallback.
+- `tests/test-backend-ops.cpp`: adds 127, 128, and 129-key correctness boundaries and PP2048 performance shapes through 512k simulated source context.
+
+## Performance data
+
+The performance rows model the actual PP2048 Indexer shapes after the source context is filled in 2048-token batches. `kv=8704` is the measured shape near 32k source context. It differs from 32768 because the Indexer compresses source tokens into rows.
+
+| Source depth | `kv` | Baseline | Optimized | Reduction |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 512 | 4.23 ms | 2.14 ms | 49.5% |
+| 8k | 2560 | 17.10 ms | 10.09 ms | 41.0% |
+| 16k | 4608 | 29.97 ms | 17.62 ms | 41.2% |
+| 32k | 8704 | 50.51 ms | 32.94 ms | 34.8% |
+| 64k | 16896 | 94.36 ms | 64.87 ms | 31.3% |
+| 128k | 33280 | 174.96 ms | 128.76 ms | 26.4% |
+| 256k | 66048 | 352.73 ms | 250.88 ms | 28.9% |
+| 512k | 131584 | 696.79 ms | 495.90 ms | 28.8% |
+
+The final isolated 32k run after cleanup measured 31.81159 ms. Small matrix differences are normal laptop GPU clock variation.
+
+| Canonical 32k metric | Baseline | Optimized |
+| --- | ---: | ---: |
+| PP2048 | 209.45 tokens/s | 216.32 tokens/s |
+| Total Vulkan | 9.73729 s | 9.42448 s |
+| Lightning Indexer | 1.11860 s | 0.697276 s |
+| Sparse FA raw | 0.198438 s | 0.195367 s |
+| Sparse FA selected | 0.835110 s | 0.843385 s |
+| Sparse FA reduce | 0.088463 s | 0.086678 s |
+| TOP_K | 0.075473 s | 0.075350 s |
+
+Logs:
+
+- Baseline matrix: `/tmp/dsv4-lightning-prefill-baseline.log`
+- Optimized matrix: `/tmp/dsv4-lightning-four-head-matrix.log`
+- Final selected-pipeline 32k microbench: `/tmp/dsv4-lightning-final-selected-32k.log`
+- Baseline canonical 32k llama-bench: `/tmp/dsv4-nathan-beta-32k-rerun-new-first.log`
+- Optimized canonical 32k llama-bench: `/tmp/dsv4-lightning-final-32k-llama-bench.log`
+
+## Correctness and resources
+
+- Wide pipeline: all 20 focused F16 cases passed, including 127, 128, and 129-key boundaries.
+- Small cooperative-matrix fallback: temporarily forced and all the same 20 cases passed.
+- Wide shader on gfx1151: 168 VGPRs, 63,488 bytes LDS, no spills, eight subgroups per SIMD.
+- The final pipeline-statistics run confirmed `lightning_indexer_cm_f16` was selected.
+- No NaN, Inf, or comparison failures were reported.
+
+Correctness logs:
+
+- Wide: `/tmp/dsv4-lightning-consolidated-wide-correctness.log`
+- Small fallback: `/tmp/dsv4-lightning-consolidated-small-correctness.log`
+
+## Experiments and decisions
+
+- Four waves improved the 32k shape about 3% and became worse at deep simulated contexts.
+- Eight waves improved it about 8% before the other changes.
+- Subgroup-scoped synchronization after cooperative-matrix stores improved the eight-wave version.
+- Staging four query heads and weights produced the large gain by reducing redundant loads and barriers.
+- Using only a subgroup barrier between head groups failed four boundary tests. One subgroup could overwrite shared query data while another still read it. A workgroup barrier is required there.
+- A separate fallback shader source was avoided. Generator definitions create both variants from one file.
+
+## Commands
+
+Build only, with no GPU benchmark running:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+git diff --check
+cmake --build build --config Release --target test-backend-ops llama-bench -j "$(nproc)"
+```
+
+Focused correctness:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+./build/bin/test-backend-ops test -b Vulkan0 -o LIGHTNING_INDEXER -p 'type_K=f16' > /tmp/dsv4-lightning-correctness.log 2>&1
+tail -n 30 /tmp/dsv4-lightning-correctness.log
+```
+
+Final 32k-equivalent microbench and pipeline selection:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+GGML_VK_PIPELINE_STATS=lightning_indexer_cm_f16 ./build/bin/test-backend-ops perf -b Vulkan0 -o LIGHTNING_INDEXER -p 'kv=8704' > /tmp/dsv4-lightning-final-selected-32k.log 2>&1
+tail -n 16 /tmp/dsv4-lightning-final-selected-32k.log
+```
+
+Full Indexer depth matrix:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+./build/bin/test-backend-ops perf -b Vulkan0 -o LIGHTNING_INDEXER -p 'nb=2048,nh=64,ns=1,nm=1,type_K=f16' > /tmp/dsv4-lightning-matrix.log 2>&1
+rg 'kv=(512|2560|4608|8704|16896|33280|66048|131584),nb=2048' /tmp/dsv4-lightning-matrix.log
+```
+
+Canonical 32k llama-bench. Run it only when needed, never while compiling, and inspect only the final block:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+GGML_VK_PERF_LOGGER=1 ./build/bin/llama-bench -m /home/jaap/Projects/docker/localLLaMA/models/models--unsloth--DeepSeek-V4-Flash-0731-GGUF/snapshots/109848da2469efe1f1aab9e11acea08a065ccd4f/UD-IQ3_XXS/DeepSeek-V4-Flash-0731-UD-IQ3_XXS-00001-of-00004.gguf -r 1 -d 32768 -p 2048 -ub 2048 -fa 1 -n 0 > /tmp/dsv4-lightning-32k-llama-bench.log 2>&1
+last=$(grep -n 'Vulkan Timings:' /tmp/dsv4-lightning-32k-llama-bench.log | tail -n 1 | cut -d: -f1)
+sed -n "${last},\$p" /tmp/dsv4-lightning-32k-llama-bench.log | tail -n 180
+```
+
+Patch inspection:
+
+```sh
+cd /tmp/llama-strix-beta-bench
+git diff --check
+git diff --stat
+git diff
+git status --short
+```
+
+## Next actions
+
+1. The user reviews and understands the four-file implementation and result summary.
+2. Commit only after explicit user approval for that commit action.
+3. Remove this scratch pad before a PR if it is not useful as permanent documentation.
+4. Restore the separate decode microbench stash from the main worktree only if that work resumes.

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1038,6 +1038,7 @@ struct vk_device_struct {
     vk_pipeline pipeline_gated_delta_net[4][2];
     vk_pipeline pipeline_lightning_indexer_f16;
     vk_pipeline pipeline_lightning_indexer_cm_f16;
+    vk_pipeline pipeline_lightning_indexer_cm_small_f16;
     vk_pipeline pipeline_lightning_indexer_decode_cm_f16;
     vk_pipeline pipeline_flash_attn_top_k_f16;
     vk_pipeline pipeline_flash_attn_top_k_cm_f16;
@@ -6131,10 +6132,18 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             device->subgroup_size);
 #if defined(VK_KHR_cooperative_matrix) && defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
         if (device->coopmat_support && device->coopmat_support_16x16x16_f32acc && device->subgroup_size_control) {
-            ggml_vk_create_pipeline(device, device->pipeline_lightning_indexer_cm_f16,
-                "lightning_indexer_cm_f16", lightning_indexer_cm_f16_len, lightning_indexer_cm_f16_data, "main", 5,
+            ggml_vk_create_pipeline(device, device->pipeline_lightning_indexer_cm_small_f16,
+                "lightning_indexer_cm_small_f16", lightning_indexer_cm_small_f16_len, lightning_indexer_cm_small_f16_data, "main", 5,
                 sizeof(vk_op_lightning_indexer_push_constants), {16, 16, 1}, {device->subgroup_size}, 1, true, true,
                 device->subgroup_size);
+            if (device->properties.limits.maxComputeWorkGroupInvocations >= 512 &&
+                device->properties.limits.maxComputeWorkGroupSize[0] >= 512 &&
+                device->properties.limits.maxComputeSharedMemorySize >= 64 * 1024) {
+                ggml_vk_create_pipeline(device, device->pipeline_lightning_indexer_cm_f16,
+                    "lightning_indexer_cm_f16", lightning_indexer_cm_f16_len, lightning_indexer_cm_f16_data, "main", 5,
+                    sizeof(vk_op_lightning_indexer_push_constants), {128, 16, 1}, {device->subgroup_size}, 1, true, true,
+                    device->subgroup_size);
+            }
             ggml_vk_create_pipeline(device, device->pipeline_lightning_indexer_decode_cm_f16,
                 "lightning_indexer_decode_cm_f16", lightning_indexer_decode_cm_f16_len, lightning_indexer_decode_cm_f16_data, "main", 5,
                 sizeof(vk_op_lightning_indexer_push_constants), {16, 1, 1}, {device->subgroup_size}, 1, true, true,
@@ -12500,8 +12509,9 @@ static vk_pipeline ggml_vk_op_get_pipeline(ggml_backend_vk_context * ctx, const 
             if (ctx->device->pipeline_lightning_indexer_decode_cm_f16 && src0->ne[2] == 1) {
                 return ctx->device->pipeline_lightning_indexer_decode_cm_f16;
             }
-            return ctx->device->pipeline_lightning_indexer_cm_f16 && src0->ne[2] >= 16 ?
-                ctx->device->pipeline_lightning_indexer_cm_f16 : ctx->device->pipeline_lightning_indexer_f16;
+            vk_pipeline cm = ctx->device->pipeline_lightning_indexer_cm_f16 ?
+                ctx->device->pipeline_lightning_indexer_cm_f16 : ctx->device->pipeline_lightning_indexer_cm_small_f16;
+            return cm && src0->ne[2] >= 16 ? cm : ctx->device->pipeline_lightning_indexer_f16;
         }
         return nullptr;
     case GGML_OP_SSM_SCAN:

--- a/ggml/src/ggml-vulkan/vulkan-shaders/lightning_indexer_cm.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/lightning_indexer_cm.comp
@@ -5,9 +5,14 @@
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
+#extension GL_KHR_shader_subgroup_basic : require
 
 layout(constant_id = 0) const uint SUBGROUP_SIZE = 64;
+#if N_WAVES == 1
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+#else
+layout(local_size_x = 512, local_size_y = 1, local_size_z = 1) in;
+#endif
 
 layout(binding = 0) readonly  buffer QBuf   { float     data_q[];    };
 layout(binding = 1) readonly  buffer KBuf   { float16_t data_k[];    };
@@ -40,13 +45,16 @@ const uint VEC_PER_HEAD = HEAD_SIZE / 4;
 const uint TILE_STRIDE = VEC_PER_HEAD + 2;
 const uint SCORE_STRIDE = TILE / 4 + 1;
 
-shared f16vec4 q_sh[TILE * TILE_STRIDE];
-shared f16vec4 k_sh[TILE * TILE_STRIDE];
-shared vec4 score_sh[TILE * SCORE_STRIDE];
+shared f16vec4 q_sh[HEADS_PER_TILE][TILE * TILE_STRIDE];
+shared f16vec4 k_sh[N_WAVES][TILE * TILE_STRIDE];
+shared vec4 score_sh[N_WAVES][TILE * SCORE_STRIDE];
+shared float weight_sh[HEADS_PER_TILE][TILE];
 
 void main() {
     const uint tid = gl_LocalInvocationIndex;
-    const uint kv_base = gl_WorkGroupID.x * TILE;
+    const uint lane = gl_SubgroupInvocationID;
+    const uint wave = gl_SubgroupID;
+    const uint kv_base = (gl_WorkGroupID.x * N_WAVES + wave) * TILE;
     const uint token_base = gl_WorkGroupID.y * TILE;
     const uint stream = gl_WorkGroupID.z;
 
@@ -55,63 +63,77 @@ void main() {
         totals[i] = 0.0;
     }
 
-    for (uint idx = tid; idx < TILE * VEC_PER_HEAD; idx += SUBGROUP_SIZE) {
-        const uint key = idx / VEC_PER_HEAD;
-        const uint d4 = idx % VEC_PER_HEAD;
-        const uint kv = kv_base + key;
+    for (uint idx = tid; idx < N_WAVES * TILE * VEC_PER_HEAD; idx += gl_WorkGroupSize.x) {
+        const uint load_wave = idx / (TILE * VEC_PER_HEAD);
+        const uint wave_idx = idx % (TILE * VEC_PER_HEAD);
+        const uint key = wave_idx / VEC_PER_HEAD;
+        const uint d4 = wave_idx % VEC_PER_HEAD;
+        const uint kv = (gl_WorkGroupID.x * N_WAVES + load_wave) * TILE + key;
         f16vec4 value = f16vec4(0.0);
         if (kv < p.n_kv) {
             const uint offset = stream * p.nbk3 + kv * p.nbk2 + d4 * 4;
             value = f16vec4(data_k[offset], data_k[offset + 1], data_k[offset + 2], data_k[offset + 3]);
         }
-        k_sh[key * TILE_STRIDE + d4] = value;
+        k_sh[load_wave][key * TILE_STRIDE + d4] = value;
     }
     barrier();
 
-    for (uint head = 0; head < N_HEAD; ++head) {
-        for (uint idx = tid; idx < TILE * VEC_PER_HEAD; idx += SUBGROUP_SIZE) {
-            const uint token_local = idx / VEC_PER_HEAD;
-            const uint d4 = idx % VEC_PER_HEAD;
+    for (uint head_base = 0; head_base < N_HEAD; head_base += HEADS_PER_TILE) {
+        for (uint idx = tid; idx < HEADS_PER_TILE * TILE * VEC_PER_HEAD; idx += gl_WorkGroupSize.x) {
+            const uint head_local = idx / (TILE * VEC_PER_HEAD);
+            const uint head_idx = idx % (TILE * VEC_PER_HEAD);
+            const uint token_local = head_idx / VEC_PER_HEAD;
+            const uint d4 = head_idx % VEC_PER_HEAD;
             const uint token = token_base + token_local;
             f16vec4 value = f16vec4(0.0);
             if (token < p.n_batch) {
-                const uint offset = stream * p.nbq3 + token * p.nbq2 + head * p.nbq1 + d4 * 4;
+                const uint offset = stream * p.nbq3 + token * p.nbq2 + (head_base + head_local) * p.nbq1 + d4 * 4;
                 value = f16vec4(data_q[offset], data_q[offset + 1], data_q[offset + 2], data_q[offset + 3]);
             }
-            q_sh[token_local * TILE_STRIDE + d4] = value;
+            q_sh[head_local][token_local * TILE_STRIDE + d4] = value;
         }
-        barrier();
-
-        coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator> scores =
-            coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator>(0.0);
-        coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> kmat;
-        coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseB> qmat;
-
-        [[unroll]] for (uint d = 0; d < HEAD_SIZE; d += TILE) {
-            coopMatLoad(kmat, k_sh, d / 4, TILE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
-            coopMatLoad(qmat, q_sh, d / 4, TILE_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
-            scores = coopMatMulAdd(kmat, qmat, scores);
-        }
-
-        coopMatStore(scores, score_sh, 0, SCORE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
-        barrier();
-
-        [[unroll]] for (uint i = 0; i < 4; ++i) {
-            const uint idx = tid + i * SUBGROUP_SIZE;
-            const uint key = idx / TILE;
-            const uint token_local = idx % TILE;
+        if (tid < HEADS_PER_TILE * TILE) {
+            const uint head_local = tid / TILE;
+            const uint token_local = tid % TILE;
             const uint token = token_base + token_local;
-            if (token < p.n_batch && kv_base + key < p.n_kv) {
-                const float score = score_sh[key * SCORE_STRIDE + token_local / 4][token_local % 4];
-                const float weight = data_w[stream * p.nbw3 + token * p.nbw1 + head];
-                totals[i] += max(score, 0.0) * weight;
+            weight_sh[head_local][token_local] = token < p.n_batch ? data_w[stream * p.nbw3 + token * p.nbw1 + head_base + head_local] : 0.0;
+        }
+        barrier();
+
+        [[unroll]] for (uint head_local = 0; head_local < HEADS_PER_TILE; ++head_local) {
+            coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator> scores =
+                coopmat<float, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseAccumulator>(0.0);
+            coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseA> kmat;
+            coopmat<float16_t, gl_ScopeSubgroup, TILE, TILE, gl_MatrixUseB> qmat;
+
+            [[unroll]] for (uint d = 0; d < HEAD_SIZE; d += TILE) {
+                coopMatLoad(kmat, k_sh[wave], d / 4, TILE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+                coopMatLoad(qmat, q_sh[head_local], d / 4, TILE_STRIDE, gl_CooperativeMatrixLayoutColumnMajor);
+                scores = coopMatMulAdd(kmat, qmat, scores);
+            }
+
+            coopMatStore(scores, score_sh[wave], 0, SCORE_STRIDE, gl_CooperativeMatrixLayoutRowMajor);
+            controlBarrier(gl_ScopeSubgroup, gl_ScopeSubgroup, gl_StorageSemanticsShared, gl_SemanticsAcquireRelease);
+
+            [[unroll]] for (uint i = 0; i < 4; ++i) {
+                const uint idx = lane + i * SUBGROUP_SIZE;
+                const uint key = idx / TILE;
+                const uint token_local = idx % TILE;
+                const uint token = token_base + token_local;
+                if (token < p.n_batch && kv_base + key < p.n_kv) {
+                    const float score = score_sh[wave][key * SCORE_STRIDE + token_local / 4][token_local % 4];
+                    totals[i] += max(score, 0.0) * weight_sh[head_local][token_local];
+                }
+            }
+            if (head_local + 1 < HEADS_PER_TILE) {
+                controlBarrier(gl_ScopeSubgroup, gl_ScopeSubgroup, gl_StorageSemanticsShared, gl_SemanticsAcquireRelease);
             }
         }
         barrier();
     }
 
     [[unroll]] for (uint i = 0; i < 4; ++i) {
-        const uint idx = tid + i * SUBGROUP_SIZE;
+        const uint idx = lane + i * SUBGROUP_SIZE;
         const uint key = idx / TILE;
         const uint token_local = idx % TILE;
         const uint kv = kv_base + key;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -802,7 +802,8 @@ void process_shaders() {
 
     string_to_spv("lightning_indexer_f16", "lightning_indexer.comp", {});
 #if defined(GGML_VULKAN_COOPMAT_GLSLC_SUPPORT)
-    string_to_spv("lightning_indexer_cm_f16", "lightning_indexer_cm.comp", {});
+    string_to_spv("lightning_indexer_cm_f16", "lightning_indexer_cm.comp", {{"N_WAVES", "8"}, {"HEADS_PER_TILE", "4"}});
+    string_to_spv("lightning_indexer_cm_small_f16", "lightning_indexer_cm.comp", {{"N_WAVES", "1"}, {"HEADS_PER_TILE", "1"}});
     string_to_spv("lightning_indexer_decode_cm_f16", "lightning_indexer_decode_cm.comp", {});
 #endif
     string_to_spv("flash_attn_top_k_f16", "flash_attn_top_k.comp", {});

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9926,6 +9926,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_lightning_indexer(128, 64, kv, 32, 4, 1, type_K));
         }
     }
+    for (int kv : { 127, 128, 129 }) {
+        test_cases.emplace_back(new test_lightning_indexer(128, 64, kv, 32, 4, 1, GGML_TYPE_F16));
+    }
 
     return test_cases;
 }
@@ -10344,6 +10347,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
                 }
             }
         }
+    }
+    // DSV4 PP2048 indexer rows after filling source contexts from 8k through 512k.
+    // The zero-depth kv=512 shape is covered above.
+    for (int kv : { 2560, 4608, 8704, 16896, 33280, 66048, 131584 }) {
+        test_cases.emplace_back(new test_lightning_indexer(128, 64, kv, 2048, 1, 1, GGML_TYPE_F16));
     }
 
     // sparse top-k FA at V4 decode/prefill shapes — the A/B instrument for the


### PR DESCRIPTION
Same disclaimer as my previous PR :)

I have measured the following performance improvements:

209 -> 214 improvement at 32k
175 -> 190 improvement at 64k

As this PR improves the lightning indexer, the improvement will grow as context depth increases as the time spent on the lightning indexer increases with increasing context length. Micro benches confirm that the performance increase hold at least until 512k context length:

| Source depth | `kv` | Baseline | Optimized | Reduction |
| ---: | ---: | ---: | ---: | ---: |
0 | 512 | 4.23 ms | 2.14 ms | 49.5% |
8k | 2560 | 17.10 ms | 10.09 ms | 41.0% |
16k | 4608 | 29.97 ms | 17.62 ms | 41.2% |
32k | 8704 | 50.51 ms | 32.94 ms | 34.8% |
64k | 16896 | 94.36 ms | 64.87 ms | 31.3% |
128k | 33280 | 174.96 ms | 128.76 ms | 26.4% |
256k | 66048 | 352.73 ms | 250.88 ms | 28.9% |
512k | 131584 | 696.79 ms | 495.90 ms | 28.8% |

It's a single commit this time.