### PR TITLE
spec: adaptive draft sizing (--spec-draft-adaptive) - port of LaurentZuijdwijk's controller

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4103,6 +4103,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             params.speculative.draft.n_min = value;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_N_MIN"));
+    add_opt(common_arg(
+        {"--spec-draft-adaptive"},
+        string_format("size each draft from measured acceptance rather than always drafting --spec-draft-n-max (default: %s)", params.speculative.draft.adaptive ? "true" : "false"),
+        [](common_params & params) {
+            params.speculative.draft.adaptive = true;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_ADAPTIVE"));
 
     add_opt(common_arg(
         {"--spec-draft-p-split", "--draft-p-split"}, "P",

--- a/common/common.h
+++ b/common/common.h
@@ -325,6 +325,9 @@ struct common_params_speculative_draft {
     int32_t n_max = 3; // maximum number of tokens to draft during speculative decoding
     int32_t n_min = 0; // minimum number of draft tokens to use for speculative decoding
 
+    // size each draft from measured acceptance instead of always drafting n_max
+    bool adaptive = false;
+
     float p_split = 0.1f; // speculative decoding split probability
     float p_min   = 0.0f; // minimum speculative decoding probability (greedy)
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <chrono>
 #include <cinttypes>
+#include <cmath>
 #include <cstring>
 #include <iomanip>
 #include <map>
@@ -152,6 +153,53 @@ struct common_speculative_impl {
 
     std::vector<size_t> n_acc_tokens_per_pos; // number of tokens accepted per draft position.
 
+    // Adaptive draft sizing (--spec-draft-adaptive): per-seq EMA of accepted tokens per
+    // draft. Censoring-aware: a fully-accepted draft only proves acceptance >= n_drafted,
+    // never how much further it would have gone, so averaging it would ratchet the draft
+    // length down and strand it. Full accept -> additive probe upward; partial accept ->
+    // EMA of the exact stopping point.
+    std::vector<float>   acc_ema;      // per-seq EMA of accepted tokens per draft
+    std::vector<int32_t> n_last_draft; // per-seq size of the draft just issued
+    bool adaptive_n = false;           // enabled by --spec-draft-adaptive
+
+    static constexpr float acc_ema_alpha  = 0.25f; // ~4-step memory
+    static constexpr float acc_ema_probe  = 1.0f;  // additive growth on a clean draft
+    static constexpr float acc_ema_init   = 2.0f;
+
+    void update_acc_ema(llama_seq_id seq_id, uint16_t n_accepted) {
+        if (seq_id < 0 || (size_t) seq_id >= acc_ema.size()) {
+            return;
+        }
+        const int32_t n_drafted = n_last_draft[seq_id];
+        if (n_drafted > 0 && (int32_t) n_accepted >= n_drafted) {
+            acc_ema[seq_id] += acc_ema_probe;   // censored: lower bound, probe up
+        } else {
+            acc_ema[seq_id] = (1.0f - acc_ema_alpha) * acc_ema[seq_id] + acc_ema_alpha * (float) n_accepted;
+        }
+        n_last_draft[seq_id] = 0;
+    }
+
+    // reset on a new prompt / reused server slot; never mid-generation, since
+    // tracking content drift within a response is the point of the EMA
+    void reset_acc_ema(llama_seq_id seq_id) {
+        if (seq_id >= 0 && (size_t) seq_id < acc_ema.size()) {
+            acc_ema[seq_id]      = acc_ema_init;
+            n_last_draft[seq_id] = 0;
+        }
+    }
+
+    // effective draft length for this step, never above the configured n_max
+    int32_t adaptive_n_draft(llama_seq_id seq_id, int32_t n_cfg, int32_t n_min) {
+        if (!adaptive_n || seq_id < 0 || (size_t) seq_id >= acc_ema.size()) {
+            return n_cfg;
+        }
+        const int32_t n_want = (int32_t) std::lround(acc_ema[seq_id]);
+        const int32_t n      = std::max(std::max(1, n_min), std::min(n_cfg, n_want));
+        acc_ema[seq_id]      = std::min(acc_ema[seq_id], (float) n_cfg); // do not let the probe run away
+        n_last_draft[seq_id] = n;
+        return n;
+    }
+
     // TODO: track performance of most recent calls
     const bool gen_perf = true; // whether to generate performance stats.
 
@@ -159,7 +207,11 @@ struct common_speculative_impl {
     int64_t t_draft_us  = 0; // total time spent in generating drafts in this implementation in microseconds.
     int64_t t_accept_us = 0; // total time spent in accumulation of this implementation in microseconds.
 
-    common_speculative_impl(common_speculative_type type, uint32_t n_seq) : type(type), n_seq(n_seq) {}
+    common_speculative_impl(common_speculative_type type, uint32_t n_seq) : type(type), n_seq(n_seq) {
+        // start optimistic so a predictable prefix is not throttled from step one
+        acc_ema.assign(n_seq, acc_ema_init);
+        n_last_draft.assign(n_seq, 0);
+    }
 
     virtual ~common_speculative_impl() = default;
 
@@ -945,6 +997,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         , params(params.draft)
         , is_dspark(type == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK)
     {
+        adaptive_n = this->params.adaptive;
+
         auto * ctx_tgt = this->params.ctx_tgt;
         auto * ctx_dft = this->params.ctx_dft;
         GGML_ASSERT(ctx_tgt && ctx_dft && "DFlash requires ctx_tgt and ctx_dft to be set");
@@ -1181,7 +1235,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
             const int32_t n = (int32_t) dp.n_past;
 
-            const int32_t n_draft = params.n_max;
+            const int32_t n_draft = adaptive_n_draft(seq_id, params.n_max, params.n_min);
 
             const int32_t n_block_tokens = n_draft + (is_dspark ? 0 : 1);
             i_block_beg[seq_id] = batch.n_tokens;
@@ -1376,6 +1430,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         : common_speculative_impl(COMMON_SPECULATIVE_TYPE_DRAFT_MTP, n_seq)
         , params(params.draft)
     {
+        adaptive_n = this->params.adaptive;
+
         auto * ctx_tgt = this->params.ctx_tgt;
         auto * ctx_dft = this->params.ctx_dft;
         GGML_ASSERT(ctx_tgt && ctx_dft && "MTP requires ctx_tgt and ctx_dft to be set");
@@ -1676,6 +1732,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 auto * smpl = smpls[seq_id].get();
 
+                // MTP drafts sequentially, so a shorter draft saves draft passes
+                // as well as target verification work.
+                const int32_t n_draft_eff = adaptive_n_draft(seq_id, params.n_max, params.n_min);
+
                 common_sampler_sample(smpl, ctx_dft, i_last[seq_id], true);
                 const float * h_row = llama_get_embeddings_nextn_ith(ctx_dft, i_last[seq_id]);
 
@@ -1705,7 +1765,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 result.push_back(id);
 
-                if (params.n_max <= (int) result.size()) {
+                if (n_draft_eff <= (int) result.size()) {
                     drafting[seq_id] = false;
                     n_drafting--;
                     continue;
@@ -2655,6 +2715,7 @@ void common_speculative_begin(common_speculative * spec, llama_seq_id seq_id, co
 
     for (auto & impl : spec->impls) {
         common_time_meas tm(impl->t_begin_us, !impl->gen_perf);
+        impl->reset_acc_ema(seq_id);
         impl->begin(seq_id, prompt);
         impl->n_call_begin++;
     }
@@ -2779,6 +2840,7 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id seq_id, u
             impl->n_acc_tokens += n_accepted;
         }
 
+        impl->update_acc_ema(seq_id, n_accepted);
         impl->accept(seq_id, n_accepted, false);
         impl->n_call_accept++;
     }


### PR DESCRIPTION
PR: spec: adaptive draft sizing (--spec-draft-adaptive) - port of LaurentZuijdwijk's controller
> aic0d3r:adaptive-verify (25a641c7f, rebased on strix-halo-vulkan df1671a03) -> Nathanw1014:strix-halo-vulkan
> Closes #11 (validation data there). Draft for review before opening.

Controller design and constants are LaurentZuijdwijk/llama.cpp b10641 - full credit for the idea. The censoring-aware EMA (full accepts probe additively, partial accepts average the exact stopping point), the constants (alpha 0.25 / probe 1.0 / init 2.0), the n_min semantics, and the content-class framing are all from his fork. This PR is the port onto strix-halo-vulkan (rebased on current tip df1671a03, one commit, ~75 lines in `common/` only, no backend changes) plus fresh validation on the rebased base.

## Mechanism

Per-seq EMA of accepted-tokens-per-draft, censoring-aware:
- partial accept -> EMA of the exact stopping point (backing off is averaged)
- full accept -> only proves acceptance >= n_drafted, so probe upward additively instead of averaging a ratcheting-down bound

Each draft is sized `clamp(round(EMA), n_min, n_max)` instead of always n_max. Defaults off; two new flags (`--spec-draft-adaptive`, `--spec-draft-n-min`), wired into the dflash and mtp draft loops.

## Validation on the REBASED base (all fresh, this week)

**PPL (spec-independent):** wikitext-2, 580x512, Qwen3.8-27B Q5_K_XL-v2:
- fa on, b4096: `7.0801 +/- 0.04626`
- fa off, b1024: `7.0838 +/- 0.04628`
- delta 0.0037, inside combined error bars; matches the pre-rebase values (7.0819 / 7.0826). Clean across kernel paths.

**Greedy determinism (honest revision of the earlier "bit-identical" claim):**
- no-spec baseline: byte-identical across independent boots (same sha256 across two fresh servers, temp 0, seed 42, first request per boot).
- spec-on arms (fixed n4 AND adaptive n3-7): each diverges from no-spec at temp 0 (divergence starts inside reasoning; fixed differs at ~char 679, adaptive at ~char 378, n=1 sample per arm). This is the known GPU verify-batch reduction class on this backend (batch composition flips near-tie argmax) - it affects fixed n4 identically, so it is a property of speculative decoding on Vulkan/FA here, not of the controller. The pre-rebase byte-identity result (issue #11) is not reproducible on the rebased base (the windowed kv-cache `get_prev_tokens` port landed in between) - reported as superseded rather than silently dropped.

**Throughput (content-class ratchet, from issue #11, same-binary A/B, every cell measured):**

| content class | fixed n4 | adaptive n3-7 | |
|---|---|---|---|
| arithmetic/patterned emission | 41.8 | 51.5 | +23% |
| agent tool-call scan loops (JSON) | 38.5 | 48.3 @ 93.8% acc | +25% |
| file edit re-emission | 35.1 | 36.7 @ 90.3% acc | +4.5% |
| JSON record generation | 34.2 | 34.3 | par |
| novel code @ 28k fill | 23.9 | 22.7 | -5% |

Not a universal win - it drafts what the acceptance histogram supports. Default recommendation stays fixed n4 for prose-heavy work; adaptive for agent/emission-heavy sessions.

**In-harness (issue #11):** three full game-build runs (low/med/high effort) with adaptive on, try-1 success each under a runtime smoke gate, decode aggregate 18-26 t/s.

## Relation to adaptive-mtp-port

Complementary, not competing: that branch is Stew's independent controller (hysteresis climb-counter with a rise-cost table, MTP-scoped, with tests); this one is the EMA design, draft-type-agnostic (dflash path included - the Qwen agent stack here runs dflash). Both independently land on the same content-class behavior; happy to run a controller-vs-controller A/B on the same binary if useful, or to rebase the dflash wiring onto that branch instead of carrying two controllers.

## Honest limits

- Loses 3-5% when acceptance genuinely decays (novel code/prose) - tracks fixed n4 minus probe overhead.
- Constants are Laurent's, not re-tuned here. Validated on one machine, one model family, dflash+mtp paths.
- Temp-0 reproducibility: see determinism section - spec decode on this backend diverges from no-spec at temp 0 regardless of controller; adaptive adds no NEW divergence mechanism (draft sizing only changes verify batch composition, same as changing n_max).
